### PR TITLE
Downloading a patched System.IO.Compression.dll for NuGet

### DIFF
--- a/Android/AndroidEasingFunctions/nuget/AndroidEasingFunctions.nuspec
+++ b/Android/AndroidEasingFunctions/nuget/AndroidEasingFunctions.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/AndroidEasingFunctions.dll" target="lib\MonoAndroid23" />
+    <file src="output/AndroidEasingFunctions.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/AndroidViewAnimations/nuget/AndroidViewAnimations.nuspec
+++ b/Android/AndroidViewAnimations/nuget/AndroidViewAnimations.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/AndroidViewAnimations.dll" target="lib\MonoAndroid23" />
+    <file src="output/AndroidViewAnimations.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/AutoFitTextView/nuget/AutoFitTextView.nuspec
+++ b/Android/AutoFitTextView/nuget/AutoFitTextView.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/AutoFitTextView.dll" target="lib\MonoAndroid403" />
+    <file src="output/AutoFitTextView.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/Android/BlurBehind/nuget/BlurBehind.nuspec
+++ b/Android/BlurBehind/nuget/BlurBehind.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/BlurBehind.dll" target="lib\MonoAndroid403" />
+    <file src="output/BlurBehind.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/Android/Blurring/nuget/Blurring.nuspec
+++ b/Android/Blurring/nuget/Blurring.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/Blurring.dll" target="lib\MonoAndroid23" />
+    <file src="output/Blurring.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/Bolts/nuget/Bolts.nuspec
+++ b/Android/Bolts/nuget/Bolts.nuspec
@@ -16,7 +16,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Bolts.Tasks.dll" target="lib\MonoAndroid403" />
-    <file src="output/Bolts.AppLinks.dll" target="lib\MonoAndroid403" />
+    <file src="output/Bolts.Tasks.dll" target="lib/MonoAndroid403" />
+    <file src="output/Bolts.AppLinks.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/Android/DeviceYearClass/nuget/DeviceYearClass.nuspec
+++ b/Android/DeviceYearClass/nuget/DeviceYearClass.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/DeviceYearClass.dll" target="lib\MonoAndroid10" />
+    <file src="output/DeviceYearClass.dll" target="lib/MonoAndroid10" />
   </files>
 </package>

--- a/Android/GoogleGson/nuget/GoogleGson.nuspec
+++ b/Android/GoogleGson/nuget/GoogleGson.nuspec
@@ -13,6 +13,6 @@
     <licenseUrl>https://github.com/xamarin/XamarinComponents/blob/master/Android/GoogleGson/License.md</licenseUrl>
   </metadata>
   <files>  
-    <file src="output/GoogleGson.dll" target="lib\MonoAndroid" />
+    <file src="output/GoogleGson.dll" target="lib/MonoAndroid" />
   </files>
 </package>

--- a/Android/MinimalJson/nuget/MinimalJson.nuspec
+++ b/Android/MinimalJson/nuget/MinimalJson.nuspec
@@ -13,6 +13,6 @@
     <licenseUrl>https://github.com/xamarin/XamarinComponents/blob/master/Android/MinimalJson/License.md</licenseUrl>
   </metadata>
   <files>  
-    <file src="output/MinimalJson.dll" target="lib\MonoAndroid23" />
+    <file src="output/MinimalJson.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/NineOldAndroids/nuget/NineOldAndroids.nuspec
+++ b/Android/NineOldAndroids/nuget/NineOldAndroids.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/NineOldAndroids.dll" target="lib\MonoAndroid23" />
+    <file src="output/NineOldAndroids.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/RecyclerViewAnimators/nuget/RecyclerViewAnimators.nuspec
+++ b/Android/RecyclerViewAnimators/nuget/RecyclerViewAnimators.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/RecyclerViewAnimators.dll" target="lib\MonoAndroid403" />
+    <file src="output/RecyclerViewAnimators.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/Android/Scissors/nuget/Scissors.Picasso.nuspec
+++ b/Android/Scissors/nuget/Scissors.Picasso.nuspec
@@ -17,6 +17,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/Lyft.Scissors.Picasso.dll" target="lib\MonoAndroid23" />
+    <file src="output/Lyft.Scissors.Picasso.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/Scissors/nuget/Scissors.nuspec
+++ b/Android/Scissors/nuget/Scissors.nuspec
@@ -13,6 +13,6 @@
     <licenseUrl>https://components.xamarin.com/license/Lyft.Scissors.Picasso</licenseUrl>
   </metadata>
   <files>  
-    <file src="output/Lyft.Scissors.dll" target="lib\MonoAndroid23" />
+    <file src="output/Lyft.Scissors.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/Screenshooter/nuget/Screenshooter.nuspec
+++ b/Android/Screenshooter/nuget/Screenshooter.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/Screenshooter.dll" target="lib\MonoAndroid23" />
+    <file src="output/Screenshooter.dll" target="lib/MonoAndroid23" />
   </files>
 </package>

--- a/Android/VectorCompat/nuget/VectorCompat.nuspec
+++ b/Android/VectorCompat/nuget/VectorCompat.nuspec
@@ -16,6 +16,6 @@
     </dependencies>
   </metadata>
   <files>  
-    <file src="output/VectorCompat.dll" target="lib\MonoAndroid403" />
+    <file src="output/VectorCompat.dll" target="lib/MonoAndroid403" />
   </files>
 </package>

--- a/XPlat/GoogleVR/Android/nuget/Xamarin.Google.VR.Android.nuspec
+++ b/XPlat/GoogleVR/Android/nuget/Xamarin.Google.VR.Android.nuspec
@@ -19,13 +19,13 @@
   <files>
 
     <!-- Android -->
-    <file src="output/Xamarin.Google.VR.Android.Audio.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.Base.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.Common.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.CommonWidget.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.Controller.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.PanoWidget.dll" target="lib\MonoAndroid44" />
-    <file src="output/Xamarin.Google.VR.Android.VideoWidget.dll" target="lib\MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.Audio.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.Base.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.Common.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.CommonWidget.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.Controller.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.PanoWidget.dll" target="lib/MonoAndroid44" />
+    <file src="output/Xamarin.Google.VR.Android.VideoWidget.dll" target="lib/MonoAndroid44" />
     
   </files>
 </package>

--- a/XPlat/GoogleVR/iOS/nuget/Xamarin.Google.VR.iOS.nuspec
+++ b/XPlat/GoogleVR/iOS/nuget/Xamarin.Google.VR.iOS.nuspec
@@ -19,10 +19,10 @@
   <files>
 
     <!-- iOS -->
-    <file src="output/Xamarin.Google.VR.iOS.dll" target="lib\Xamarin.iOS10" />
+    <file src="output/Xamarin.Google.VR.iOS.dll" target="lib/Xamarin.iOS10" />
 
     <!-- Add targets file for external native reference download -->
-    <file src="source/Google.VR.iOS/Google.VR.iOS.targets" target="build\Xamarin.Google.VR.iOS.targets"  />
+    <file src="source/Google.VR.iOS/Google.VR.iOS.targets" target="build/Xamarin.Google.VR.iOS.targets"  />
     
   </files>
 </package>

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,12 @@
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
-NUGET_EXE=$TOOLS_DIR/nuget.exe
+export NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
+
+# BEGIN TEMP WORKAROUND
+SYSIOCOMP=$TOOLS_DIR/System.IO.Compression.dll
+# END TEMP WORKAROUND
 
 # Define default arguments.
 SCRIPT="build.cake"
@@ -52,12 +56,26 @@ fi
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
-    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1
     fi
 fi
+
+# BEGIN TEMP WORKAROUND
+# There is a bug in Mono's System.IO.Compression
+# This binary fixes the bug for now
+# Download System.IO.Compression if it does not exist.
+if [ ! -f "$SYSIOCOMP" ]; then
+    echo "Downloading System.IO.Compression.dll ..."
+    curl -Lsfo "$SYSIOCOMP" http://xamarin-components-binaries.s3.amazonaws.com/System.IO.Compression.dll
+    if [ $? -ne 0 ]; then
+        echo "An error occured while downloading System.IO.Compression.dll."
+        exit 1
+    fi
+fi
+# END TEMP WORKAROUND
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null

--- a/iOS/DACircularProgress/nuget/DACircularProgress.nuspec
+++ b/iOS/DACircularProgress/nuget/DACircularProgress.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>https://components.xamarin.com/license/DACircularProgress</licenseUrl>
   </metadata>
   <files>
-    <file src="output/unified/DACircularProgress.dll" target="lib\Xamarin.iOS" />
-    <file src="output/classic/DACircularProgress.dll" target="lib\MonoTouch" />
+    <file src="output/unified/DACircularProgress.dll" target="lib/Xamarin.iOS" />
+    <file src="output/classic/DACircularProgress.dll" target="lib/MonoTouch" />
   </files>
 </package>

--- a/iOS/GPUImage/nuget/GPUImage.nuspec
+++ b/iOS/GPUImage/nuget/GPUImage.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>https://components.xamarin.com/license/gpuimage</licenseUrl>
   </metadata>
   <files>
-    <file src="output/unified/GPUImage.dll" target="lib\Xamarin.iOS" />
-    <file src="output/classic/GPUImage.dll" target="lib\MonoTouch" />
+    <file src="output/unified/GPUImage.dll" target="lib/Xamarin.iOS" />
+    <file src="output/classic/GPUImage.dll" target="lib/MonoTouch" />
   </files>
 </package>

--- a/iOS/MBProgressHUD/nuget/MBProgressHUD.nuspec
+++ b/iOS/MBProgressHUD/nuget/MBProgressHUD.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>https://components.xamarin.com/license/mbprogresshud</licenseUrl>
   </metadata>
   <files>
-    <file src="output/unified/MBProgressHUD.dll" target="lib\Xamarin.iOS" />
-    <file src="output/classic/MBProgressHUD.dll" target="lib\MonoTouch" />
+    <file src="output/unified/MBProgressHUD.dll" target="lib/Xamarin.iOS" />
+    <file src="output/classic/MBProgressHUD.dll" target="lib/MonoTouch" />
   </files>
 </package>

--- a/iOS/Masonry/nuget/Masonry.nuspec
+++ b/iOS/Masonry/nuget/Masonry.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>https://components.xamarin.com/license/Masonry</licenseUrl>
   </metadata>
   <files>
-    <file src="output/unified/Masonry.dll" target="lib\Xamarin.iOS" />
-    <file src="output/classic/Masonry.dll" target="lib\MonoTouch" />
+    <file src="output/unified/Masonry.dll" target="lib/Xamarin.iOS" />
+    <file src="output/classic/Masonry.dll" target="lib/MonoTouch" />
   </files>
 </package>

--- a/iOS/SDWebImage/nuget/SDWebImage.nuspec
+++ b/iOS/SDWebImage/nuget/SDWebImage.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>https://components.xamarin.com/license/sdwebimage</licenseUrl>
   </metadata>
   <files>
-    <file src="output/unified/SDWebImage.dll" target="lib\Xamarin.iOS" />
-    <file src="output/classic/SDWebImage.dll" target="lib\MonoTouch" />
+    <file src="output/unified/SDWebImage.dll" target="lib/Xamarin.iOS" />
+    <file src="output/classic/SDWebImage.dll" target="lib/MonoTouch" />
   </files>
 </package>


### PR DESCRIPTION
There appears to be an issue with Mono’s compression.  I believe it
is linked to this commit.

https://github.com/mono/mono/commit/77b034cbe78bfccfe4c1995152bd5562a1d69ef5

That commit changed the ‘version made by’ instead of the ‘version needed to extract.’
I believe this is the correct fix

https://gist.github.com/bholmes/09c9a4e5a5c9a2f14831a7b2b7ce89aa

The dll downloaded has that patch with the mono-4.4.0-branch-c7-baseline/5995f74
version.  I will work with the Mono team to get this resolved and we can remove this
when the fix propagates to the build bots officially.

Without this patch NuGet 3.4.4 creates a corrupt nupkg.
