### PR TITLE
[mapbox] change url for nuget icons to github repo

### DIFF
--- a/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.Android.nuspec
+++ b/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.Android.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright © Xamarin. All Rights Reserved.</copyright>
     <projectUrl>https://components.xamarin.com/view/mapboxsdk</projectUrl>
     <licenseUrl>https://components.xamarin.com/license/mapboxsdk</licenseUrl>
-    <iconUrl>http://xamarin-component-icons.s3.amazonaws.com/Xamarin.MapboxSDK.Android.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/xamarin/XamarinComponents/master/XPlat/Mapbox/component/icons/mapboxsdk_128x128.png</iconUrl>
     <dependencies>
       <dependency id="Square.OkHttp3" version="3.4.1.1"/>
       <dependency id="Square.OkIO" version="1.6.0.0"/>

--- a/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.AndroidServices.nuspec
+++ b/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.AndroidServices.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright © Xamarin. All Rights Reserved.</copyright>
     <projectUrl>https://components.xamarin.com/view/mapboxsdk</projectUrl>
     <licenseUrl>https://components.xamarin.com/license/mapboxsdk</licenseUrl>
-    <iconUrl>http://xamarin-component-icons.s3.amazonaws.com/Xamarin.MapboxSDK.Android.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/xamarin/XamarinComponents/master/XPlat/Mapbox/component/icons/mapboxsdk_128x128.png</iconUrl>
     <dependencies>
       <dependency id="Xamarin.Android.Support.Design" version="23.4.0.1"/>
       <dependency id="Xamarin.Android.Support.v7.AppCompat" version="23.4.0.1"/>

--- a/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.JavaServices.nuspec
+++ b/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.JavaServices.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright © Xamarin. All Rights Reserved.</copyright>
     <projectUrl>https://components.xamarin.com/view/mapboxsdk</projectUrl>
     <licenseUrl>https://components.xamarin.com/license/mapboxsdk</licenseUrl>
-    <iconUrl>http://xamarin-component-icons.s3.amazonaws.com/Xamarin.MapboxSDK.Android.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/xamarin/XamarinComponents/master/XPlat/Mapbox/component/icons/mapboxsdk_128x128.png</iconUrl>
     <dependencies>
       <dependency id="Square.OkHttp3" version="3.4.1.1" />
       <dependency id="Square.OkIO" version="1.6.0.0" />

--- a/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.iOS.nuspec
+++ b/XPlat/Mapbox/nuget/Xamarin.MapboxSDK.iOS.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright © Xamarin. All Rights Reserved.</copyright>
     <projectUrl>https://components.xamarin.com/view/mapboxsdk</projectUrl>
     <licenseUrl>https://components.xamarin.com/license/mapboxsdk</licenseUrl>
-    <iconUrl>http://xamarin-component-icons.s3.amazonaws.com/Xamarin.MapboxSDK.iOS.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/xamarin/XamarinComponents/master/XPlat/Mapbox/component/icons/mapboxsdk_128x128.png</iconUrl>
   </metadata>
   <files>
 


### PR DESCRIPTION
Icons were still pulling from old location, moving to github repo