### PR TITLE
Add option to overwrite the source assembly in XBD

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3-beta1</version>
+    <version>0.4.3-beta2</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3-beta2</version>
+    <version>0.4.3-beta3</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3-beta3</version>
+    <version>0.4.3-beta4</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -69,6 +69,7 @@
 			<Output TaskParameter="RemovedReferencePaths" ItemName="_ResourceRestoreRemovedReferencePaths" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="ReferencePath" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="FileWrites" />
+			<Output TaskParameter="AdditionalFileWrites" ItemName="FileWrites" />
 		</XamarinBuildiOSResourceRestore>
 		<ItemGroup>
 			<ReferencePath Remove="@(_ResourceRestoreRemovedReferencePaths)" />
@@ -90,6 +91,7 @@
 			<Output TaskParameter="RemovedReferencePaths" ItemName="_ResourceRestoreRemovedReferencePaths" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="ReferencePath" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="FileWrites" />
+			<Output TaskParameter="AdditionalFileWrites" ItemName="FileWrites" />
 		</XamarinBuildAndroidResourceRestore>
 		<ItemGroup>
 			<ReferencePath Remove="@(_ResourceRestoreRemovedReferencePaths)" />
@@ -110,6 +112,7 @@
 			<Output TaskParameter="RemovedReferencePaths" ItemName="_ResourceRestoreRemovedReferencePaths" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="ReferencePath" />
 			<Output TaskParameter="ChangedReferencePaths" ItemName="FileWrites" />
+			<Output TaskParameter="AdditionalFileWrites" ItemName="FileWrites" />
 		</XamarinBuildAndroidAarRestore>
 		<ItemGroup>
 			<ReferencePath Remove="@(_ResourceRestoreRemovedReferencePaths)" />

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidResourceRestore.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Build.Download
 		[Required]
 		public string TargetFrameworkVerison { get; set; }
 
+		public override bool OverwiteSourceAssembly { get; set; } = true;
+
 		protected override IAssemblyResolver CreateAssemblyResolver ()
 		{
 			var resolver = new DefaultAssemblyResolver ();

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidResourceRestore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,7 +15,7 @@ namespace Xamarin.Build.Download
 		[Required]
 		public string TargetFrameworkVerison { get; set; }
 
-		public override bool OverwiteSourceAssembly { get; set; } = true;
+		public override bool OverwriteSourceAssembly { get; set; } = true;
 
 		protected override IAssemblyResolver CreateAssemblyResolver ()
 		{


### PR DESCRIPTION
With Android builds we are seeing a number of issues

 - Warnings that assemblies referenced from the NuGet can not be found
   (Not errors from what I can tell.)
 - Build time errors on first build because resources can not be found
   (Clean builds appear to fix this too, but yuck)
 - Slow VS experience when IDE is at idle.  We believe this is because of
   design time builds that are running.  Changing the reference list after
   references are resolved causes more processes to spawn.

 This patch avoids changing the reference list after the resolve assembly step runs.
 Instead the source assembly is updated and written back to the same location and not
 the intermediate directory.  It appears to work in the cases I tested but we need to
 run a full set and have the community tell us how it is working.

 There is now a property on all of the resource restore tasks that allow the behavior to be configured.
 On Android we default to overwrite and on iOS we continue to use the intermediate folder by default.

 We need to add an optimization to know if we need to open the assembly in cecil.  Right now we always
 open the file.  It is taking a second in my tests.  We could write out and check for a 'marker' file.

 This will buy us some more time as a temporary workaround.  We are working on changes
 needed in Xamarin Android so that we can add aar files to the project build list and not
 require that we re-embed the aar or reference files.