### PR TITLE
[XBD] Always add .stamp files as FileWrites

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3-beta4</version>
+    <version>0.4.3-beta5</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Build.Download
 				var stampAsmPath = intermediateAsmPath + ".stamp";
 
 				if (File.Exists (stampAsmPath)) {
+					additionalFileWrites.Add (new TaskItem (stampAsmPath));
 					Log.LogMessage ("Reference has already had resources merged, skipping due to: {0}", stampAsmPath);
 					continue;
 				}

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
@@ -56,8 +56,6 @@ namespace Xamarin.Build.Download
 			var outputDir = MergeOutputDir;
 			Directory.CreateDirectory (outputDir);
 
-			additionalFileWrites.Add (new TaskItem (outputDir));
-
 			var restoreMap = BuildRestoreMap (RestoreAssemblyResources);
 			if (restoreMap == null) {
 				return false;


### PR DESCRIPTION
Even if we didn’t create them this run, we want them cleaned up on a build->clean invocation if they exist.