### PR TITLE
[xbd] Fix iOS incremental builds

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3-beta5</version>
+    <version>0.4.3-beta6</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
@@ -86,10 +86,8 @@ namespace Xamarin.Build.Download
 				if (File.Exists (stampAsmPath)) {
 					additionalFileWrites.Add (new TaskItem (stampAsmPath));
 					Log.LogMessage ("Reference has already had resources merged, skipping due to: {0}", stampAsmPath);
-					continue;
-				}
-				
-				if (OverwriteSourceAssembly || !File.Exists(intermediateAsmPath) || File.GetLastWriteTime (intermediateAsmPath) < File.GetLastWriteTime (originalAsmPath)) {
+
+				} else if (OverwriteSourceAssembly || !File.Exists(intermediateAsmPath) || File.GetLastWriteTime (intermediateAsmPath) < File.GetLastWriteTime (originalAsmPath)) {
 					if (resolver == null)
 						resolver = CreateAssemblyResolver ();
 					if (!MergeResources (resolver, originalAsmPath, outputAsmPath, asm.Key, asm.Value))


### PR DESCRIPTION
We were skipping changing the reference paths for builds that
do not overwrite the source dll.  When we skip the write the
compiler is pointing to the wrong or source dll.  Need to point to
the dll in the intermediate path.