### PR TITLE
[XBD] Added some simple AndroidManifest.xml fixups

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.3</version>
+    <version>0.4.4-beta1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
@@ -47,6 +47,7 @@
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarRestore.cs
@@ -2,11 +2,15 @@
 using System.IO.Compression;
 using System.IO;
 using System.Linq;
+using Microsoft.Build.Framework;
+using System.Xml.Linq;
 
 namespace Xamarin.Build.Download
 {
 	public class XamarinBuildAndroidAarRestore : XamarinBuildAndroidResourceRestore
 	{
+		public bool FixAndroidManifests { get; set; } = true;
+
 		protected override Stream LoadResource (string resourceFullPath, string assemblyName)
 		{
 			const string AAR_DIR_PREFIX = "library_project_imports";
@@ -14,7 +18,7 @@ namespace Xamarin.Build.Download
 			var memoryStream = new MemoryStream ();
 			using (var fileStream = base.LoadResource (resourceFullPath, assemblyName))
 				fileStream.CopyTo (memoryStream);
-			
+
 			using (var zipArchive = new ZipArchive (memoryStream, ZipArchiveMode.Update, true)) {
 
 				var entryNames = zipArchive.Entries.Select (zae => zae.FullName).ToList ();
@@ -52,11 +56,50 @@ namespace Xamarin.Build.Download
 						// Create a new entry based on our new name
 						var newEntry = zipArchive.CreateEntry (newName);
 
-						// Copy file contents over if they exist
-						if (oldEntry.Length > 0) {
+						// Since Xamarin.Android's AndoridManifest.xml merging code is not as sophisticated as gradle's yet, we may need
+						// to fix some things up in the manifest file to get it to merge properly into our applications
+						// Here we will check to see if Fixing manifests was enabled, and if the entry we are on is the AndroidManifest.xml file
+						if (FixAndroidManifests && oldEntry.Length > 0 && newName.EndsWith ("AndroidManifest.xml", StringComparison.OrdinalIgnoreCase)) {
+
+							// android: namespace
+							XNamespace xns = "http://schemas.android.com/apk/res/android";
+
 							using (var oldStream = oldEntry.Open ())
-							using (var newStream = newEntry.Open ()) {
-								oldStream.CopyTo (newStream);
+							using (var xmlReader = System.Xml.XmlReader.Create (oldStream)) {
+								var xdoc = XDocument.Load (xmlReader);
+
+								// BEGIN FIXUP #1
+								// Some `android:name` attributes will start with a . indicating, that the `package` value of the `manifest` element
+								// should be prefixed dynamically/at merge to this attribute value.  Xamarin.Android doesn't handle this case yet
+								// so we are going to manually take care of it.
+
+								// Get the package name from the manifest node
+								var packageName = xdoc.Document.Descendants ("manifest")?.FirstOrDefault ()?.Attribute ("package")?.Value;
+
+								if (!string.IsNullOrEmpty (packageName)) {
+									// Find all elements in the xml document that have a `android:name` attribute which starts with a .
+									// Select all of them, and then change the `android:name` attribute value to be the
+									// package name we found in the `manifest` element previously + the original attribute value
+									xdoc.Document.Descendants ()
+										.Where (elem => elem.Attribute (xns + "name")?.Value?.StartsWith (".", StringComparison.Ordinal) ?? false)
+										.ToList ()
+										.ForEach (elem => elem.SetAttributeValue (xns + "name", packageName + elem.Attribute (xns + "name").Value));
+								}
+								// END FIXUP #1
+
+								using (var newStream = newEntry.Open ())
+								using (var xmlWriter = System.Xml.XmlWriter.Create (newStream)) {
+									xdoc.WriteTo (xmlWriter);
+								}
+							}
+
+						} else {
+							// Copy file contents over if they exist
+							if (oldEntry.Length > 0) {
+								using (var oldStream = oldEntry.Open ())
+								using (var newStream = newEntry.Open ()) {
+									oldStream.CopyTo (newStream);
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Currently, as of 15.1, Xamarin.Android has a really simple implementation of merging AndroidManifest.xml files from referenced .aar’s into the app’s manifest.

One merge feature we need in Google Play Services is the ability for `android:name` attributes having values starting with a `.` to have the package name from the `manifest` element’s `package` attribute merged into the `android:name` attribute value.

For example, in Google Play Services Ads we may have:
```
<manifest package="com.google.android.gms.auth.api" ... >
    <application>
      <activity android:name=".signin.internal.SignInHubActivity" ... />
      ...
```

However, the merged `activity` element should end up coming in as:
```
<activity android:name="com.google.android.gms.auth.api.signin.internal.SignInHubActivity" ... />
```

Until Xamarin.Android supports this, we are adding the ability to patch the manifest on the fly when reembedding it.  We may add other fixes in the future, but for now we will fix up the name attributes.