### PR TITLE
[JSQMessagesViewController] Upgrade to version v7.3.4

### DIFF
--- a/iOS/JSQMessagesViewController/component/component.yaml
+++ b/iOS/JSQMessagesViewController/component/component.yaml
@@ -2,7 +2,7 @@
 ---
 name: JSQMessagesViewController
 id: jsqmessagesviewcontroller
-version: 7.2.0
+version: 7.3.4
 summary: An elegant messages UI library for iOS
 publisher: Xamarin Inc.
 publisher-url: http://xamarin.com

--- a/iOS/JSQMessagesViewController/externals/Makefile
+++ b/iOS/JSQMessagesViewController/externals/Makefile
@@ -17,7 +17,7 @@ ios/JSQSystemSoundPlayer/JSQSystemSoundPlayer/Classes/JSQSystemSoundPlayer.h :
 ios/JSQMessagesViewController/JSQMessagesViewController/JSQMessages.h : ios/JSQSystemSoundPlayer/JSQSystemSoundPlayer/Classes/JSQSystemSoundPlayer.h 
 	mkdir -p ios
 	cd ios && git clone git@github.com:jessesquires/JSQMessagesViewController.git
-	cd ios/JSQMessagesViewController && git checkout 7.2.0
+	cd ios/JSQMessagesViewController && git checkout 7.3.4
 	mkdir ios/JSQMessagesViewController/JSQMessagesViewController/JSQSystemSoundPlayer
 	cp ios/JSQSystemSoundPlayer/JSQSystemSoundPlayer/Classes/* ios/JSQMessagesViewController/JSQMessagesViewController/JSQSystemSoundPlayer/
 	sed -i '' 's/#import <JSQSystemSoundPlayer\/JSQSystemSoundPlayer.h>/#import "JSQSystemSoundPlayer.h"/g' ios/JSQMessagesViewController/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.h

--- a/iOS/JSQMessagesViewController/externals/ios/JSQMessagesViewControllerLib/JSQMessagesViewControllerLib.xcodeproj/project.pbxproj
+++ b/iOS/JSQMessagesViewController/externals/ios/JSQMessagesViewControllerLib/JSQMessagesViewControllerLib.xcodeproj/project.pbxproj
@@ -44,7 +44,9 @@
 		2188DD5A1AD876C30043EFEE /* JSQMessagesMediaPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188DD311AD876C30043EFEE /* JSQMessagesMediaPlaceholderView.m */; };
 		2188DD5B1AD876C30043EFEE /* JSQMessagesToolbarContentView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188DD331AD876C30043EFEE /* JSQMessagesToolbarContentView.m */; };
 		2188DD5C1AD876C30043EFEE /* JSQMessagesTypingIndicatorFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2188DD361AD876C30043EFEE /* JSQMessagesTypingIndicatorFooterView.m */; };
-		21F26A4D1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 21F26A4C1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m */; settings = {ASSET_TAGS = (); }; };
+		21F26A4D1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = 21F26A4C1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m */; };
+		8B08D3B71EA2A2C600BBA178 /* JSQAudioMediaItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B08D3B61EA2A2C600BBA178 /* JSQAudioMediaItem.m */; };
+		8B08D3BA1EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B08D3B91EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -152,6 +154,10 @@
 		21F26A4A1BD16100006C6198 /* JSQMessagesBubbleSizeCalculating.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesBubbleSizeCalculating.h; sourceTree = "<group>"; };
 		21F26A4B1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesBubblesSizeCalculator.h; sourceTree = "<group>"; };
 		21F26A4C1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesBubblesSizeCalculator.m; sourceTree = "<group>"; };
+		8B08D3B51EA2A2C600BBA178 /* JSQAudioMediaItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQAudioMediaItem.h; sourceTree = "<group>"; };
+		8B08D3B61EA2A2C600BBA178 /* JSQAudioMediaItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQAudioMediaItem.m; sourceTree = "<group>"; };
+		8B08D3B81EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQAudioMediaViewAttributes.h; sourceTree = "<group>"; };
+		8B08D3B91EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQAudioMediaViewAttributes.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -268,6 +274,8 @@
 		2188DCFE1AD876C30043EFEE /* Layout */ = {
 			isa = PBXGroup;
 			children = (
+				8B08D3B81EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.h */,
+				8B08D3B91EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.m */,
 				21F26A4A1BD16100006C6198 /* JSQMessagesBubbleSizeCalculating.h */,
 				21F26A4B1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.h */,
 				21F26A4C1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m */,
@@ -284,6 +292,8 @@
 		2188DD051AD876C30043EFEE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				8B08D3B51EA2A2C600BBA178 /* JSQAudioMediaItem.h */,
+				8B08D3B61EA2A2C600BBA178 /* JSQAudioMediaItem.m */,
 				2188DD061AD876C30043EFEE /* JSQLocationMediaItem.h */,
 				2188DD071AD876C30043EFEE /* JSQLocationMediaItem.m */,
 				2188DD081AD876C30043EFEE /* JSQMediaItem.h */,
@@ -408,10 +418,12 @@
 				2188DD4C1AD876C30043EFEE /* JSQMessage.m in Sources */,
 				2188DD431AD876C30043EFEE /* JSQMessagesMediaViewBubbleImageMasker.m in Sources */,
 				2188DD4A1AD876C30043EFEE /* JSQLocationMediaItem.m in Sources */,
+				8B08D3BA1EA2A2D500BBA178 /* JSQAudioMediaViewAttributes.m in Sources */,
 				2188DD471AD876C30043EFEE /* JSQMessagesCollectionViewFlowLayout.m in Sources */,
 				2188DD591AD876C30043EFEE /* JSQMessagesLoadEarlierHeaderView.m in Sources */,
 				2188DD4B1AD876C30043EFEE /* JSQMediaItem.m in Sources */,
 				21F26A4D1BD16100006C6198 /* JSQMessagesBubblesSizeCalculator.m in Sources */,
+				8B08D3B71EA2A2C600BBA178 /* JSQAudioMediaItem.m in Sources */,
 				2188DD401AD876C30043EFEE /* JSQMessagesViewController.m in Sources */,
 				2188DD531AD876C30043EFEE /* JSQMessagesCollectionViewCell.m in Sources */,
 				2188DD5B1AD876C30043EFEE /* JSQMessagesToolbarContentView.m in Sources */,

--- a/iOS/JSQMessagesViewController/samples/XamarinChat/MessageFactory.cs
+++ b/iOS/JSQMessagesViewController/samples/XamarinChat/MessageFactory.cs
@@ -27,10 +27,12 @@ namespace XamarinChat
 		public async Task <Message> CreateMessageAsync (User user)
 		{
 			var rnd = new Random ();
-			var choice = rnd.Next () % 3;
+			var choice = rnd.Next () % 4;
 
 			if (choice == 0)
-				return CreateMonkeyMessage (user);
+				return CreateMonkeyMessage(user);
+			else if (choice == 3)
+				return CreateAudioMessage(user);
 
 			return await CreateOverflowMessageAsync (choice == 2 ? "dogoverflow.com" : "catoverflow.com", user);
 		}
@@ -59,6 +61,15 @@ namespace XamarinChat
 			var photoItem = new PhotoMediaItem (image);
 			photoItem.AppliesMediaViewMaskAsOutgoing = false;
 			return Message.Create (user.Id, user.DisplayName, photoItem);
+		}
+
+		Message CreateAudioMessage(User user)
+		{
+			NSUrl localFileUrl = NSBundle.MainBundle.GetUrlForResource("jsq_messages_sample", "m4a");
+			var audioData = NSData.FromUrl(localFileUrl);
+			var audioItem = new AudioMediaItem(audioData);
+			audioItem.AudioViewAttributes.PauseButtonImage = UIImageExtensions.DefaultPauseImage;
+			return Message.Create(user.Id, user.DisplayName, audioItem);
 		}
 			
 		UIImage CreateAnimatedImage (byte [] data)

--- a/iOS/JSQMessagesViewController/samples/XamarinChat/XamarinChat.csproj
+++ b/iOS/JSQMessagesViewController/samples/XamarinChat/XamarinChat.csproj
@@ -111,6 +111,9 @@
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
     <BundleResource Include="Resources\XamarinLogo.png" />
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesDemo\jsq_messages_sample.m4a">
+      <Link>Resources\jsq_messages_sample.m4a</Link>
+    </BundleResource>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\source\JSQMessagesViewController\JSQMessagesViewController.csproj">

--- a/iOS/JSQMessagesViewController/source/JSQMessagesViewController/Additions.cs
+++ b/iOS/JSQMessagesViewController/source/JSQMessagesViewController/Additions.cs
@@ -81,6 +81,8 @@ namespace JSQMessagesViewController
 
 		private static object __mt_DefaultPlayImage_var_static;
 
+		private static object __mt_DefaultPauseImage_var_static;
+
 		private static object __mt_DefaultAccessoryImage_var_static;
 
 		private static object __mt_BubbleRegularTaillessImage_var_static;
@@ -185,6 +187,20 @@ namespace JSQMessagesViewController
 				return nSObject;
 			}
 		}
+		
+		public static UIImage DefaultPauseImage
+		{
+			[Export("jsq_defaultPauseImage")]
+			get
+			{
+				UIImage nSObject = Runtime.GetNSObject<UIImage>(Messaging.IntPtr_objc_msgSend(UIImageExtensions.class_ptr, Selector.GetHandle("jsq_defaultPauseImage")));
+				if (!NSObject.IsNewRefcountEnabled()) 
+				{
+					UIImageExtensions.__mt_DefaultPauseImage_var_static = nSObject; 
+				}
+				return nSObject;
+			}
+		} 
 
 		public static UIImage DefaultTypingIndicatorImage {
 			[Export ("jsq_defaultTypingIndicatorImage")]

--- a/iOS/JSQMessagesViewController/source/JSQMessagesViewController/ApiDefinition.cs
+++ b/iOS/JSQMessagesViewController/source/JSQMessagesViewController/ApiDefinition.cs
@@ -6,6 +6,7 @@ using ObjCRuntime;
 using CoreGraphics;
 using MapKit;
 using CoreLocation;
+using AVFoundation;
 
 namespace JSQMessagesViewController
 {
@@ -609,6 +610,22 @@ namespace JSQMessagesViewController
 		// -(void)scrollToBottomAnimated:(BOOL)animated;
 		[Export ("scrollToBottomAnimated:")]
 		void ScrollToBottom (bool animated);
+
+		// - (BOOL)isOutgoingMessage:(id<JSQMessageData>)messageItem;
+		[Export("isOutgoingMessage:")]
+		bool IsOutgoingMessage(MessageData messageData);
+
+		// - (void)scrollToIndexPath:(NSIndexPath *)indexPath animated:(BOOL)animated;
+		[Export("scrollToIndexPath:animated:")]
+		bool ScrollToIndexPath(NSIndexPath indexPath, bool animated);
+
+		// - (void)didReceiveMenuWillShowNotification:(NSNotification *)notification;
+		[Export("didReceiveMenuWillShowNotification:")]
+		bool ReceivedMenuWillShowNotification(NSNotification messageData);
+
+		// - (void)didReceiveMenuWillHideNotification:(NSNotification *)notification;
+		[Export("didReceiveMenuWillHideNotification:")]
+		bool ReceivedMenuWillHideNotification(NSNotification messageData);
 	}
 
 	// @interface JSQMessagesCollectionViewCellIncoming : JSQMessagesCollectionViewCell
@@ -874,6 +891,76 @@ namespace JSQMessagesViewController
 		// -(void)clearCachedMediaViews;
 		[Export ("clearCachedMediaViews")]
 		void ClearCachedMediaViews ();
+	}
+
+	// @interface JSQAudioMediaItem : JSQMediaItem <JSQMessageMediaData, AVAudioPlayerDelegate, NSCoding, NSCopying>
+	[BaseType(typeof(MediaItem), Name = "JSQAudioMediaItem")]
+	interface AudioMediaItem : MessageMediaData, IAVAudioPlayerDelegate, INSCoding, INSCopying
+	{
+		// +@property(nonatomic, strong, readonly) JSQAudioMediaViewAttributes* audioViewAttributes;
+		[Export("audioViewAttributes", ArgumentSemantic.Strong)]
+		AudioMediaViewAttributes AudioViewAttributes { get; }
+
+		// @property (nonatomic, strong, nullable) NSData *audioData;
+		[NullAllowed, Export("audioData", ArgumentSemantic.Strong)]
+		NSData AudioData { get; set; }
+
+		// - (instancetype)initWithData:(nullable NSData *)audioData
+		[Export("initWithData:")]
+		IntPtr Constructor(NSData audioData);
+
+		// - (instancetype)initWithData:(nullable NSData *)audioData audioViewAttributes:(JSQAudioMediaViewAttributes*)audioViewAttributes
+		[Export("initWithImage:audioViewAttributes:")]
+		IntPtr Constructor(NSData audioData, AudioMediaViewAttributes audioViewAttributes);
+
+		// - (instancetype)initWithAudioViewAttributes:(JSQAudioMediaViewAttributes *)audioViewAttributes;
+		[Export("initWithAudioViewAttributes:")]
+		IntPtr Constructor(AudioMediaViewAttributes audioViewAttributes);
+
+		// - (void)setAudioDataWithUrl:(nonnull NSURL *)audioURL;
+		[Export("setAudioDataWithUrl:")]
+		void SetAudioDataWithUrl(NSUrl audioURL);
+	}
+
+	// @interface JSQAudioMediaViewAttributes : NSObject
+	[BaseType(typeof(NSObject), Name = "JSQAudioMediaViewAttributes")]
+	interface AudioMediaViewAttributes
+	{
+		// @property (nonatomic, strong) UIImage *playButtonImage;
+		[Export("playButtonImage", ArgumentSemantic.Strong)]
+		UIImage PlayButtonImage { get; set; }
+
+		// @property (nonatomic, strong) UIImage *pauseButtonImage;
+		[Export("pauseButtonImage", ArgumentSemantic.Strong)]
+		UIImage PauseButtonImage { get; set; }
+
+		// @property (strong, nonatomic) UIFont *labelFont;
+		[Export("labelFont", ArgumentSemantic.Strong)]
+		UIFont LabelFont { get; set; }
+
+		// @property (nonatomic, assign) BOOL showFractionalSeconds;
+		[Export("showFractionalSeconds", ArgumentSemantic.Assign)]
+		bool ShowFractionalSeconds { get; set; }
+
+		// @property (nonatomic, strong) UIColor *backgroundColor;
+		[Export("backgroundColor", ArgumentSemantic.Strong)]
+		UIColor BackgroundColor { get; set; }
+
+		// @property (nonatomic, strong) UIColor *tintColor;
+		[Export("tintColor", ArgumentSemantic.Strong)]
+		UIColor TintColor { get; set; }
+
+		// @property (nonatomic, assign) UIEdgeInsets controlInsets;
+		[Export("controlInsets", ArgumentSemantic.Assign)]
+		UIEdgeInsets ControlInsets { get; set; }
+
+		// @property (nonatomic, assign) CGFloat controlPadding;
+		[Export("controlPadding", ArgumentSemantic.Assign)]
+		nfloat ControlPadding { get; set; }
+		
+		// - (instancetype)initWithPlayButtonImage:(UIImage *)playButtonImage pauseButtonImage:(UIImage*)pauseButtonImage labelFont:(UIFont*)labelFont showFractionalSecodns:(BOOL)showFractionalSeconds backgroundColor:(UIColor*)backgroundColor tintColor:(UIColor*)tintColor controlInsets:(UIEdgeInsets)controlInsets controlPadding:(CGFloat)controlPadding audioCategory:(NSString*)audioCategory audioCategoryOptions:(AVAudioSessionCategoryOptions)audioCategoryOptions
+		[Export("initWithPlayButtonImage:pauseButtonImage:labelFont:showFractionalSecodns:backgroundColor:tintColor:controlInsets:controlPadding:audioCategory:audioCategoryOptions:")]
+		IntPtr Constructor(UIImage playButtonImage, UIImage pauseButtonImage, UIFont labelFont, bool showFractionalSeconds, UIColor backgroundColor, UIColor tintColor, UIEdgeInsets controlInsets, nfloat controlPadding, NSString audioCategory, AVAudioSessionCategoryOptions audioCategoryOptions);
 	}
 
 	// @interface JSQPhotoMediaItem : JSQMediaItem <JSQMessageMediaData, NSCoding, NSCopying>

--- a/iOS/JSQMessagesViewController/source/JSQMessagesViewController/JSQMessagesViewController.csproj
+++ b/iOS/JSQMessagesViewController/source/JSQMessagesViewController/JSQMessagesViewController.csproj
@@ -58,6 +58,24 @@
     </ObjcBindingNativeLibrary>
   </ItemGroup>
   <ItemGroup>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesCollectionViewCellIncoming.nib">
+      <Link>Resources\JSQMessagesCollectionViewCellIncoming.nib</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesCollectionViewCellOutgoing.nib">
+      <Link>Resources\JSQMessagesCollectionViewCellOutgoing.nib</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesLoadEarlierHeaderView.nib">
+      <Link>Resources\JSQMessagesLoadEarlierHeaderView.nib</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesToolbarContentView.nib">
+      <Link>Resources\JSQMessagesToolbarContentView.nib</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesTypingIndicatorFooterView.nib">
+      <Link>Resources\JSQMessagesTypingIndicatorFooterView.nib</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesViewController.nib">
+      <Link>Resources\JSQMessagesViewController.nib</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Base.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\Base.lproj\JSQMessages.strings</Link>
     </BundleResource>
@@ -124,6 +142,15 @@
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Images\clip%403x.png">
       <Link>Resources\JSQMessagesAssets.bundle\Images\clip%403x.png</Link>
     </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Images\pause.png">
+      <Link>Resources\JSQMessagesAssets.bundle\Images\pause.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Images\pause%402x.png">
+      <Link>Resources\JSQMessagesAssets.bundle\Images\pause%402x.png</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Images\pause%403x.png">
+      <Link>Resources\JSQMessagesAssets.bundle\Images\pause%403x.png</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Images\play.png">
       <Link>Resources\JSQMessagesAssets.bundle\Images\play.png</Link>
     </BundleResource>
@@ -148,6 +175,9 @@
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\Sounds\message_sent.aiff">
       <Link>Resources\JSQMessagesAssets.bundle\Sounds\message_sent.aiff</Link>
     </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\ar.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\ar.lproj\JSQMessages.strings</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\de.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\de.lproj\JSQMessages.strings</Link>
     </BundleResource>
@@ -157,14 +187,32 @@
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\es.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\es.lproj\JSQMessages.strings</Link>
     </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\fi.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\fi.lproj\JSQMessages.strings</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\fr.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\fr.lproj\JSQMessages.strings</Link>
     </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\he.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\he.lproj\JSQMessages.strings</Link>
     </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\id.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\id.lproj\JSQMessages.strings</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\it.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\it.lproj\JSQMessages.strings</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\ja.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\ja.lproj\JSQMessages.strings</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\ko.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\ko.lproj\JSQMessages.strings</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\ms.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\ms.lproj\JSQMessages.strings</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\nb.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\nb.lproj\JSQMessages.strings</Link>
     </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\nl.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\nl.lproj\JSQMessages.strings</Link>
@@ -181,32 +229,20 @@
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\ru.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\ru.lproj\JSQMessages.strings</Link>
     </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\th.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\th.lproj\JSQMessages.strings</Link>
+    </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\tr.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\tr.lproj\JSQMessages.strings</Link>
+    </BundleResource>
+    <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\vi.lproj\JSQMessages.strings">
+      <Link>Resources\JSQMessagesAssets.bundle\vi.lproj\JSQMessages.strings</Link>
     </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\zh-Hans.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\zh-Hans.lproj\JSQMessages.strings</Link>
     </BundleResource>
     <BundleResource Include="..\..\externals\ios\JSQMessagesViewController\JSQMessagesViewController\Assets\JSQMessagesAssets.bundle\zh-Hant.lproj\JSQMessages.strings">
       <Link>Resources\JSQMessagesAssets.bundle\zh-Hant.lproj\JSQMessages.strings</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesCollectionViewCellIncoming.nib">
-      <Link>Resources\JSQMessagesCollectionViewCellIncoming.nib</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesCollectionViewCellOutgoing.nib">
-      <Link>Resources\JSQMessagesCollectionViewCellOutgoing.nib</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesLoadEarlierHeaderView.nib">
-      <Link>Resources\JSQMessagesLoadEarlierHeaderView.nib</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesToolbarContentView.nib">
-      <Link>Resources\JSQMessagesToolbarContentView.nib</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesTypingIndicatorFooterView.nib">
-      <Link>Resources\JSQMessagesTypingIndicatorFooterView.nib</Link>
-    </BundleResource>
-    <BundleResource Include="..\..\externals\ios\Resources\JSQMessagesViewController.nib">
-      <Link>Resources\JSQMessagesViewController.nib</Link>
     </BundleResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR includes the upgrade of JSQMessagesViewController from version 7.2.0 to 7.3.4.
[JSQMessagesViewController 7.3.4](https://github.com/jessesquires/JSQMessagesViewController/releases/tag/7.3.4)

- Update ApiDefinition & Additions
- Change JSQMessagesViewControllerLib project
- Added AudioMessage to XamarinChat example
