### PR TITLE
[cake] Add-In for helping with binding build tasks

### DIFF
--- a/Util/Cake.Xamarin.Binding.Util/External-Dependency-Info.txt
+++ b/Util/Cake.Xamarin.Binding.Util/External-Dependency-Info.txt
@@ -1,0 +1,42 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Build Download incorporates third party 
+material from the projects listed below. The original copyright notice and 
+the license under which Microsoft received such third party material are set 
+forth below.  Microsoft reserves all other rights not expressly granted, 
+whether by implication, estoppel or otherwise.
+
+############################################
+# Cecil
+# https://github.com/jbevain/cecil
+############################################
+
+Copyright (c) 2008 - 2015 Jb Evain
+Copyright (c) 2008 - 2011 Novell, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+You may obtain a copy of the license here:
+https://github.com/jbevain/cecil/blob/master/LICENSE.txt
+
+############################################
+# end - Cecil
+############################################

--- a/Util/Cake.Xamarin.Binding.Util/External-Dependency-Info.txt
+++ b/Util/Cake.Xamarin.Binding.Util/External-Dependency-Info.txt
@@ -15,6 +15,31 @@ whether by implication, estoppel or otherwise.
 Copyright (c) 2008 - 2015 Jb Evain
 Copyright (c) 2008 - 2011 Novell, Inc.
 
+--------------------------------------------
+Other files from source have specific copyrights:
+--------------------------------------------
+/cecil/symbols/mdb/Mono.CompilerServices.SymbolWriter/SourceMethodBuilder.cs
+  (C) 2002 Ximian, Inc.  http://www.ximian.com
+  Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
+
+/cecil/Mono.Security.Cryptography/CryptoConvert.cs
+  (C) 2003 Motus Technologies Inc. (http://www.motus.com)
+  Copyright (C) 2004-2006 Novell Inc. (http://www.novell.com)
+
+/cecil/symbols/mdb/Mono.CompilerServices.SymbolWriter/MonoSymbolWriter.cs
+  (C) 2002 Ximian, Inc.  http://www.ximian.com
+
+/cecil/symbols/mdb/Mono.CompilerServices.SymbolWriter/SymbolWriterImpl.cs
+  (C) 2005 Novell, Inc.  http://www.novell.com
+
+/cecil/symbols/mdb/Mono.CompilerServices.SymbolWriter/MonoSymbolFile.cs
+  (C) 2003 Ximian, Inc.  http://www.ximian.com
+  Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
+
+/cecil/symbols/mdb/Mono.CompilerServices.SymbolWriter/MonoSymbolTable.cs
+  (C) 2002 Ximian, Inc.  http://www.ximian.com
+--------------------------------------------
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including
@@ -37,6 +62,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 You may obtain a copy of the license here:
 https://github.com/jbevain/cecil/blob/master/LICENSE.txt
 
+
+---------------------------------------------
+Other files from source have specific notice:
+---------------------------------------------
+Copyright (c) Microsoft. All rights reserved.
+This code is licensed under the Microsoft Public License.
+THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+---------------------------------------------
+
 ############################################
 # end - Cecil
 ############################################
+

--- a/Util/Cake.Xamarin.Binding.Util/LICENSE
+++ b/Util/Cake.Xamarin.Binding.Util/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Xamarin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Util/Cake.Xamarin.Binding.Util/LICENSE
+++ b/Util/Cake.Xamarin.Binding.Util/LICENSE
@@ -1,21 +1,9 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 Xamarin
+Copyright (c) .NET Foundation Contributors
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Util/Cake.Xamarin.Binding.Util/README.md
+++ b/Util/Cake.Xamarin.Binding.Util/README.md
@@ -1,0 +1,22 @@
+Cake.Xamarin.Binding.Util
+=========================
+
+An Add-In for [Cake Build](http://cakebuild.net) which contains some useful aliases for Xamarin's binding projects.
+
+
+**FindObfuscations**
+
+Finds likely obfuscated types and members based on the java type or member name.
+NOTE: The default regex pattern looks for types or members with only 3 character long names.
+
+```csharp
+FindObfuscationResults FindObfuscations (FilePath assembly, bool ignoreDefaultExceptions = false, bool ignoreMembers = false, bool ignoreTypes = false, string[] regexPatterns = null);
+```
+
+**FindMissingMetadata**
+
+Finds members of types in an assembly which do not have proper names (eg: p0, P1, etc) which means they are missing metadata from the Android binding.
+
+```csharp
+List<MetadataMemberInfo> FindMissingMetadata (FilePath assembly)
+```

--- a/Util/Cake.Xamarin.Binding.Util/build.cake
+++ b/Util/Cake.Xamarin.Binding.Util/build.cake
@@ -1,0 +1,27 @@
+#load "../../common.cake"
+
+var TARGET = Argument ("t", Argument ("target", "Default"));
+
+var buildSpec = new BuildSpec {
+	Libs = new [] { 
+		new DefaultSolutionBuilder {
+			SolutionPath = "source/Cake.Xamarin.Binding.Util.sln",
+			BuildsOn = BuildPlatforms.Windows | BuildPlatforms.Mac,
+			OutputFiles = new [] { 
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Cake.Xamarin.Binding.Util.dll" },
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Cake.Xamarin.Binding.Util.xml" },
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Mono.Cecil.dll" },
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Mono.Cecil.Mdb.dll" },
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Mono.Cecil.Pdb.dll" },
+				new OutputFileCopy { FromFile = "./source/Cake.Xamarin.Binding.Util/bin/Release/Mono.Cecil.Rocks.dll" },
+			},
+		}
+	},
+	NuGets = new [] {
+		new NuGetInfo { NuSpec = "./nuget/Cake.Xamarin.Binding.Util.nuspec" },
+	}
+};
+
+SetupXamarinBuildTasks (buildSpec, Tasks, Task);
+
+RunTarget (TARGET);

--- a/Util/Cake.Xamarin.Binding.Util/nuget/Cake.Xamarin.Binding.Util.nuspec
+++ b/Util/Cake.Xamarin.Binding.Util/nuget/Cake.Xamarin.Binding.Util.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Cake.Xamarin.Binding.Util</id>
+    <title>Cake Add-In providing utilities for Xamarin Binding build scripts</title>
+    <version>1.0.0</version>
+    <authors>Xamarin Inc.</authors>
+    <owners>Xamarin Inc.</owners>
+    <licenseUrl>https://github.com/xamarin/XamarinComponents/blob/master/Util/Cake.Xamarin.Binding.Util/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Cake Add-In providing utilities for Xamarin Binding build scripts</description>
+    <copyright>Copyright 2017</copyright>
+  </metadata>
+  <files>
+    <file src="output/Cake.Xamarin.Binding.Util.dll" target="lib/net45" />
+    <file src="output/Cake.Xamarin.Binding.Util.xml" target="lib/net45" />
+    
+    <file src="output/Mono.Cecil.dll" target="lib/net45" />
+    <file src="output/Mono.Cecil.Mdb.dll" target="lib/net45" />
+    <file src="output/Mono.Cecil.Pdb.dll" target="lib/net45" />
+    <file src="output/Mono.Cecil.Rocks.dll" target="lib/net45" />
+
+    <file src="External-Dependency-Info.txt" target="THIRD-PARTY-NOTICES.txt" />
+  </files>
+</package>

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util.sln
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Xamarin.Binding.Util", "Cake.Xamarin.Binding.Util\Cake.Xamarin.Binding.Util.csproj", "{F0B68902-8694-401A-BC34-4E17DF770F98}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F0B68902-8694-401A-BC34-4E17DF770F98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0B68902-8694-401A-BC34-4E17DF770F98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0B68902-8694-401A-BC34-4E17DF770F98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0B68902-8694-401A-BC34-4E17DF770F98}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Aliases.cs
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Aliases.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+
+namespace Cake.Xamarin.Binding.Util
+{
+	[CakeAliasCategory("Xamarin Binding Utilities")]
+	public static class BindingUtilAliases
+	{
+		/// <summary>
+		/// Finds likely obfuscated types and members based on the java type or member name.
+		/// The default regex pattern looks for types or members with only 3 character long names.
+		/// </summary>
+		/// <returns>The obfuscations.</returns>
+		/// <param name="context">The context.</param>
+		/// <param name="assembly">The assembly file to search in.</param>
+		/// <param name="ignoreDefaultExceptions">If set to <c>true</c> ignore default exceptions (such as to, for, at, etc).</param>
+		/// <param name="ignoreMembers">If set to <c>true</c> ignore members.</param>
+		/// <param name="ignoreTypes">If set to <c>true</c> ignore types.</param>
+		/// <param name="regexPatterns">Custom regex patterns to use instead of the default.  These are based on a single line regex.</param>
+		[CakeMethodAlias]
+		public static FindObfuscationResults FindObfuscations (ICakeContext context, FilePath assembly, bool ignoreDefaultExceptions = false, bool ignoreMembers = false, bool ignoreTypes = false, string[] regexPatterns = null)
+		{
+			return Obfuscations.Find(assembly.MakeAbsolute(context.Environment).FullPath, ignoreDefaultExceptions, ignoreMembers, ignoreTypes, regexPatterns);
+		}
+
+		/// <summary>
+		/// Finds members of types in an assembly which do not have proper names (eg: p0, P1, etc) which means they are missing metadata from the Android binding.
+		/// </summary>
+		/// <returns>The missing metadata.</returns>
+		/// <param name="context">The context.</param>
+		/// <param name="assembly">The assembly file to search in.</param>
+		[CakeMethodAlias]
+		public static List<MetadataMemberInfo> FindMissingMetadata (ICakeContext context, FilePath assembly)
+		{
+			return AndroidMetadata.FindMissing(assembly.MakeAbsolute(context.Environment).FullPath);
+		}
+	}
+}

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Cake.Xamarin.Binding.Util.csproj
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Cake.Xamarin.Binding.Util.csproj
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F0B68902-8694-401A-BC34-4E17DF770F98}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Cake.Xamarin.Binding.Util</RootNamespace>
+    <AssemblyName>Cake.Xamarin.Binding.Util</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Cake.Xamarin.Binding.Util.xml</DocumentationFile>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Cake.Core">
+      <HintPath>..\packages\Cake.Core.0.21.1\lib\net45\Cake.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="Cake.Common">
+      <HintPath>..\packages\Cake.Common.0.21.1\lib\net45\Cake.Common.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Aliases.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Obfuscation\Obfuscations.cs" />
+    <Compile Include="Metadata\AndroidMetadata.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Obfuscation\" />
+    <Folder Include="Metadata\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Metadata/AndroidMetadata.cs
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Metadata/AndroidMetadata.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+
+namespace Cake.Xamarin.Binding.Util
+{
+	static class AndroidMetadata
+	{
+		public static List<MetadataMemberInfo> FindMissing(string assemblyFile)
+		{
+			var results = new List<MetadataMemberInfo>();
+
+			var assembly = AssemblyDefinition.ReadAssembly(assemblyFile);
+
+			var types = new List<TypeDefinition>();
+
+
+			Action<IMemberDefinition> addMember = (IMemberDefinition member) =>
+			{
+				if (!results.Any(r => r.NetMember.FullName.Equals(member.FullName)))
+					results.Add(new MetadataMemberInfo { NetMember = member });
+			};
+
+			// Get *ALL* types and nested types from both assemblies
+			foreach (var m in assembly.Modules)
+				types.AddRange(m.GetAllTypes());
+
+			foreach (var t in types)
+			{
+				if (t.IsNotPublic)
+					continue;
+
+				var printedType = false;
+
+				foreach (var m in t.Methods)
+				{
+					if (!m.IsPublic)
+						continue;
+					
+					if (!m.HasParameters)
+						continue;
+
+					foreach (var p in m.Parameters) {
+						if (IsBadName(p.Name)) {
+							addMember(m);
+							break;
+						}
+					}
+				}
+
+				foreach (var f in t.Fields)
+				{
+					if (!f.IsPublic)
+						continue;
+
+					if (IsBadName(f.Name))
+						addMember(f);
+				}
+
+				foreach (var p in t.Properties)
+				{
+					if (IsBadName(p.Name))
+						addMember(p);
+				}
+			}
+
+			return results;
+		}
+
+		static Regex rxBadName = new Regex("^[pP]{1}[0-9]+$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+		static bool IsBadName(string name)
+		{
+			if (string.IsNullOrEmpty(name))
+				return false;
+
+			name = name.Trim();
+
+			return rxBadName.IsMatch(name);
+		}
+	}
+
+	public class MetadataMemberInfo
+	{
+		public IMemberDefinition NetMember { get; set; }
+	}
+}

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Obfuscation/Obfuscations.cs
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Obfuscation/Obfuscations.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Cake.Core.IO;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+
+namespace Cake.Xamarin.Binding.Util
+{
+	class Obfuscations
+	{
+		static string[] OBFUSCATED_EXCEPTIONS = { "or", "if", "not", "get", "set", "add", "and", "tag", "api", "end", "put", "log", "url" };
+		static bool showHelp = false;
+		static bool ignoreDefaultExceptions = false;
+		static List<string> exceptions = new List<string>();
+		static List<string> regexes = new List<string>();
+		static bool ignoreMembers = false;
+		static bool ignoreTypes = false;
+
+		public static FindObfuscationResults Find(string assemblyFile, bool ignoreDefaultExceptions = false, bool ignoreMembers = false, bool ignoreTypes = false, string[] regexPatterns = null)
+		{
+			if (!ignoreDefaultExceptions)
+				exceptions.AddRange(OBFUSCATED_EXCEPTIONS);
+
+			if (!regexes.Any())
+				regexes.Add("^[a-zA-Z]{1,3}$");
+
+			//regexes.Add("^internal/.*$");
+
+			var assembly = AssemblyDefinition.ReadAssembly(assemblyFile);
+
+			var types = new List<TypeDefinition>();
+
+			var results = new FindObfuscationResults ();
+			var obfuscatedTypes = new Dictionary<string, ObfuscatedTypeInfo>();
+			var obfuscatedMembers = new Dictionary<string, ObfuscatedMemberInfo>();
+
+			// Get *ALL* types and nested types from both assemblies
+			foreach (var m in assembly.Modules)
+			{
+				types.AddRange(m.GetAllTypes());
+			}
+
+			foreach (var t in types)
+			{
+
+				var tj = GetJavaName(t.CustomAttributes);
+
+				if (!ignoreTypes)
+				{
+					if (!string.IsNullOrEmpty(tj))
+					{
+						if (!obfuscatedTypes.ContainsKey(tj))
+							obfuscatedTypes.Add(tj, new ObfuscatedTypeInfo { NetType = t, JavaType = tj });
+					}
+				}
+
+				if (!ignoreMembers)
+				{
+					foreach (var m in t.Methods)
+					{
+						if (!m.HasCustomAttributes)
+							continue;
+
+						var j = GetJavaName(m.CustomAttributes);
+
+						if (!string.IsNullOrEmpty(j))
+						{
+							if (!obfuscatedMembers.ContainsKey(j))
+								obfuscatedMembers.Add(j, new ObfuscatedMemberInfo { NetType = m.DeclaringType, NetMember = m, JavaMember = j });
+						}
+					}
+
+					foreach (var f in t.Fields)
+					{
+						if (!f.HasCustomAttributes)
+							continue;
+
+						var j = GetJavaName(f.CustomAttributes);
+
+						if (!string.IsNullOrEmpty(j))
+						{
+							if (!obfuscatedMembers.ContainsKey(j))
+								obfuscatedMembers.Add(j, new ObfuscatedMemberInfo { NetType = f.DeclaringType, NetMember = f, JavaMember = j });
+						}
+					}
+
+					foreach (var p in t.Properties)
+					{
+						if (!p.HasCustomAttributes)
+							continue;
+
+						var j = GetJavaName(p.CustomAttributes);
+
+						if (!string.IsNullOrEmpty(j))
+						{
+							if (!obfuscatedMembers.ContainsKey(j))
+								obfuscatedMembers.Add(j, new ObfuscatedMemberInfo { NetType = p.DeclaringType, NetMember = p, JavaMember = j });
+						}
+					}
+				}
+			}
+
+			if (obfuscatedTypes != null && obfuscatedTypes.Count > 0)
+				results.Types.AddRange(obfuscatedTypes.Values);
+
+			if (obfuscatedMembers != null && obfuscatedMembers.Count > 0)
+				results.Members.AddRange(obfuscatedMembers.Values);
+
+			return results;
+		}
+
+
+
+		static void parseExceptions(string e)
+		{
+			if (string.IsNullOrEmpty(e))
+				return;
+
+			var items = e.Split(',', ';');
+
+			if (items == null)
+				return;
+
+			foreach (var i in items)
+			{
+				if (string.IsNullOrEmpty(i))
+					continue;
+
+				exceptions.Add(i.Trim());
+			}
+		}
+
+		static string GetJavaName(Mono.Collections.Generic.Collection<CustomAttribute> attributes)
+		{
+			string name = null;
+
+			foreach (var a in attributes)
+			{
+				if (a.AttributeType.Name == "RegisterAttribute")
+				{
+
+					if (a.HasConstructorArguments)
+					{
+						name = a.ConstructorArguments[0].Value as string;
+						break;
+					}
+				}
+			}
+
+			if (string.IsNullOrEmpty(name))
+				return null;
+
+
+			var fullName = name;
+
+			if (name.Contains('/'))
+				name = name.Substring(name.LastIndexOf('/') + 1);
+
+			if (exceptions.Contains(name.ToLowerInvariant()))
+				return null;
+
+
+			var matched = false;
+			foreach (var r in regexes)
+			{
+				if (Regex.IsMatch(name, r, RegexOptions.Singleline) || Regex.IsMatch(fullName, r, RegexOptions.Singleline))
+				{
+					matched = true;
+					break;
+				}
+			}
+
+			if (!matched)
+				return null;
+
+			return fullName;
+		}
+
+		static void ExtractTypes(List<TypeDefinition> types, TypeDefinition typeDef)
+		{
+			if (!typeDef.IsPublic)
+				return;
+
+			types.Add(typeDef);
+
+			foreach (var nestedType in typeDef.NestedTypes)
+				ExtractTypes(types, nestedType);
+		}
+	}
+
+	public class ObfuscatedTypeInfo
+	{
+		public TypeDefinition NetType { get; set; }
+		public string JavaType { get; set; }
+	}
+
+	public class ObfuscatedMemberInfo
+	{
+		public TypeDefinition NetType { get; set; }
+		public IMemberDefinition NetMember { get; set; }
+		public string JavaMember { get; set; }
+	}
+
+	public class FindObfuscationResults
+	{
+		public List<ObfuscatedTypeInfo> Types { get; set; } = new List<ObfuscatedTypeInfo>();
+		public List<ObfuscatedMemberInfo> Members { get; set; } = new List<ObfuscatedMemberInfo>();
+	}
+}

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Properties/AssemblyInfo.cs
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/Properties/AssemblyInfo.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("Cake.Xamarin.Binding.Util")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("${AuthorCopyright}")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.0.0")]
+
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]

--- a/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/packages.config
+++ b/Util/Cake.Xamarin.Binding.Util/source/Cake.Xamarin.Binding.Util/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Cake.Common" version="0.21.1" targetFramework="net461" />
+  <package id="Cake.Core" version="0.21.1" targetFramework="net461" />
+  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net461" />
+</packages>

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -402,3 +402,7 @@
   BuildScript: ./Util/Xamarin.Build.Download/build.cake
   TriggerPaths: [ Util/Xamarin.Build.Download ]
   MacBuildTargets: [ nuget ]
+- Name: Cake.Xamarin.Binding.Util
+  BuildScript: ./Util/Cake.Xamarin.Binding.Util/build.cake
+  TriggerPaths: [ Util/Cake.Xamarin.Binding.Util ]
+  MacBuildTargets: [ nuget ]


### PR DESCRIPTION
This is going to be an addin which contains some utilities to help automate some binding build script tasks.

To start, there are aliases for finding obfuscated member/type info in an assembly, and one for finding members with names indicating they are missing metadata (for android bindings).