### PR TITLE
[xbd] Add `ResolveAssemblyReferences` dependency

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -14,12 +14,12 @@
 
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='Xamarin.iOS' And ('$(OutputType)' != 'Library' OR '$(IsAppExtension)'=='True')">
 		<_XamarinBuildDownloadMasterBeforeTargets>_UnpackLibraryResources</_XamarinBuildDownloadMasterBeforeTargets>
-		<_XamarinBuildDownloadMasterDependsOnTargets>_XamarinBuildDownload;_XamariniOSBuildResourceRestore</_XamarinBuildDownloadMasterDependsOnTargets>
+		<_XamarinBuildDownloadMasterDependsOnTargets>ResolveAssemblyReferences;_XamarinBuildDownload;_XamariniOSBuildResourceRestore</_XamarinBuildDownloadMasterDependsOnTargets>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'">
 		<_XamarinBuildDownloadMasterBeforeTargets>_ResolveLibraryProjectImports</_XamarinBuildDownloadMasterBeforeTargets>
-		<_XamarinBuildDownloadMasterDependsOnTargets>_XamarinBuildDownload;_XamarinAndroidBuildResourceRestore;_XamarinAndroidBuildAarRestore;_XamarinAndroidBuildAarProguardConfigs</_XamarinBuildDownloadMasterDependsOnTargets>
+		<_XamarinBuildDownloadMasterDependsOnTargets>ResolveAssemblyReferences;_XamarinBuildDownload;_XamarinAndroidBuildResourceRestore;_XamarinAndroidBuildAarRestore;_XamarinAndroidBuildAarProguardConfigs</_XamarinBuildDownloadMasterDependsOnTargets>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
It’s possible to invoke a build of a project via msbuild which does not hit a path causing `ResolveAssemblyReferences` target to run.

Eg:
```
msbuild /t:UpdateAndroidResources /p:DesignTimeBuild=true /p:BuildingInsideVisualStudio=true /v:diag AndroidApp.csproj
```

This adds the `ResolveAssemblyReferences` target as a dependency of both the iOS and Android _master_ targets in Xamarin.Build.Download to ensure they are run and our references are resolved.