### PR TITLE
[Mono.Options] Fix typo in a few places.

### DIFF
--- a/XPlat/Mono.Options/README.md
+++ b/XPlat/Mono.Options/README.md
@@ -40,7 +40,7 @@ options expected:
         { "h|help", "show this message and exit", h => shouldShowHelp = h != null },
     };
 
-Then, in the `static void Main (string[] args)` method, we can parse the incomming 
+Then, in the `static void Main (string[] args)` method, we can parse the incoming 
 arguments and get a list of any extras:
 
     List<string> extra;

--- a/XPlat/Mono.Options/component/Details.md
+++ b/XPlat/Mono.Options/component/Details.md
@@ -26,7 +26,7 @@ options expected:
         { "h|help", "show this message and exit", h => shouldShowHelp = h != null },
     };
 
-Then, in the `static void Main (string[] args)` method, we parse the incomming 
+Then, in the `static void Main (string[] args)` method, we parse the incoming 
 arguments and get a list of any extras:
 
     List<string> extra;

--- a/XPlat/Mono.Options/component/GettingStarted.md
+++ b/XPlat/Mono.Options/component/GettingStarted.md
@@ -29,7 +29,7 @@ options expected:
         { "h|help", "show this message and exit", h => shouldShowHelp = h != null },
     };
 
-Then, in the `static void Main (string[] args)` method, we parse the incomming 
+Then, in the `static void Main (string[] args)` method, we parse the incoming 
 arguments and get a list of any extras:
 
     List<string> extra;


### PR DESCRIPTION
Looks like it was copy-pasted across a few docs.