### PR TITLE
[Xamarin.Build.Download] Fix potential race condition while reading/writing assemblies

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.7</version>
+    <version>0.4.8-beta1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865061</projectUrl>


### PR DESCRIPTION
We have a potential race condition reported by a customer where somehow (even though it’s in a try/catch block), the `asmDefinition.Write (mergedAsmPath);` call is throwing in some cases due to a file access error (specifically file in use by another process).

There are a couple of possibilities:
 1. The file is actually still open by another msbuild invocation or another msbuild task running (either from our own tasks here, or some other part of the build process).
 2. Some previous process didn’t clean up the file completely, and it’s left in an open state.

I think 1 is most likely, since this seems to happen randomly and not always (and subsequent builds sometimes have the issue and sometimes do not).

This set of changes introduces a number of safeguards to mitigate the possibility of a race condition:

1. Using `IBuildEngine4` it registers the assembly being processed with the build engine for the given task so that other calls to the same task within the build engine (eg: building in parallel) can skip over processing for the assemblies already processed or in the middle of processing.
2. Also using the build engine global dictionary, the `AssemblyName` is cached for each assembly file read, so that subsequent calls can use the cached value instead of opening the assembly and reading it.
3. An exclusive read file lock is created on the assembly filename + ".lock".  each time the code intends to open the assembly for reading/writing, it will first attempt to obtain this exclusive lock before proceeding, which should ensure no other processes running our task should have the given assembly open already.
4. The build task now implements `ICancelableTask`.  This allows the wait on the exclusive read/file lock to be cancelled part way through the build (the wait can be as long as 60 seconds, so it's important this was cancelable).

**Proguard**
There was an issue with the proguard task where config files extracted and cached into the intermediate output dir were not being emitted to the FileWrites item group on subsequent incremental builds because the .stamp file was checked and then the task skipped if it existed.  This PR now makes the cached proguard config file paths saved to the .stamp file so subsequent incremental builds can read them from the .stamp file and emit them to the FileWrites item group.