### PR TITLE
[xbd] Prevent possible race conditions accessing the assemblies for resource merging

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/AsyncTask.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/AsyncTask.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Build.Download
 				LogDebugMessage ("    {0}", item.ItemSpec);
 		}
 
-		protected void LogMessage (string message, params object [] messageArgs)
+		public void LogMessage (string message, params object [] messageArgs)
 		{
 			LogMessage (string.Format (message, messageArgs));
 		}
@@ -116,7 +116,7 @@ namespace Xamarin.Build.Download
 			LogError (code, string.Format (message, messageArgs));
 		}
 
-		protected void LogError (string code, string message)
+        protected void LogError (string code, string message)
 		{
 			if (UIThreadId == Thread.CurrentThread.ManagedThreadId)
 				#pragma warning disable 618

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/BaseXamarinBuildResourceRestore.cs
@@ -212,12 +212,14 @@ namespace Xamarin.Build.Download
 					AssemblyName aname = null;
 
 					// Try and get the assembly name a few times in case something is locking it
-					for (int i = 0; i < 5; i++) {
+					for (int i = 0; i < 10; i++) {
 						try {
-							using (var xlock = DownloadUtils.ObtainExclusiveFileLock (asmPath + ".lock", cancelToken, TimeSpan.FromSeconds (30)))
+							//using (var xlock = DownloadUtils.ObtainExclusiveFileLock (asmPath + ".lock", cancelToken, TimeSpan.FromSeconds (30)))
 								aname = AssemblyName.GetAssemblyName (asmPath);
 							break;
-						} catch { }
+						} catch {
+							Thread.Sleep (250);
+						}
 					}
 
 					// If still null, we failed several attempts

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
@@ -241,15 +241,23 @@ namespace Xamarin.Build.Download
 			
 			while (!linkedCancelTokenSource.IsCancellationRequested) {
 				try {
+                    log.LogMessage("Trying to obtain exclusive lock on: {0}", file);
 					var lockStream = File.Open (file, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-					return lockStream;
+                    log.LogMessage("Obtained exclusive lock on: {0}", file);
+                    return lockStream;
 				} catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException) {
-					Thread.Sleep (100);
+                    log?.LogMessage("Waiting for exclusive lock on: {0}", file);
+                    Thread.Sleep (100);
 				} catch (Exception ex) {
 					log?.LogErrorFromException (ex);
-				}
+                    Thread.Sleep(100);
+                }
 			}
 
+            if (linkedCancelTokenSource.IsCancellationRequested)
+            {
+                log.LogMessage("Exclusive lock failed (canceled) on: {0}", file);
+            }
 			return null;
 		}
 

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/MSBuildExtensions.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/MSBuildExtensions.cs
@@ -21,5 +21,7 @@ namespace Xamarin.Build.Download
 	{
 		void LogCodedError (string code, string message, params object [] messageArgs);
 		void LogErrorFromException (System.Exception exception);
+
+        void LogMessage(string message, params object[] param);
 	}
 }

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/TaskExtensions.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/TaskExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace Xamarin.Build.Download
+{
+	public class TaskExtensions
+	{
+		public BuildHost ()
+		{
+		}
+	}
+}

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -78,7 +78,6 @@
     <Compile Include="XamarinBuildAndroidAarProguardConfigs.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="README.md" />
     <None Include="Xamarin.Build.Download.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -27,21 +27,17 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.0-beta7\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
@@ -82,8 +78,10 @@
     <Compile Include="XamarinBuildAndroidAarProguardConfigs.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="README.md" />
     <None Include="Xamarin.Build.Download.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </None>
     <None Include="packages.config" />
     <None Include="Xamarin.Build.Download.props">

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarProguardConfigs.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarProguardConfigs.cs
@@ -77,7 +77,12 @@ namespace Xamarin.Build.Download
 					// Full path to .aar file
 					var resourceFullPath = resourceItem.GetMetadata ("FullPath");
 
-					using (var fileStream = File.OpenRead (resourceFullPath))
+                    var tempFile = Path.GetTempFileName();
+
+                    if (!DownloadUtils.CopyFileWithRetry(resourceFullPath, tempFile, Log))
+                        return false;
+
+                    using (var fileStream = File.OpenRead (tempFile))
 					using (var zipArchive = new ZipArchive (fileStream, ZipArchiveMode.Read)) {
 
 						// Look for proguard config files in the archive

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarProguardConfigs.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarProguardConfigs.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Build.Download
 			Directory.CreateDirectory (outputDir);
 
 			// Get our assembly restore map
-			var restoreMap = BuildRestoreMap (RestoreAssemblyResources);
+			var restoreMap = BuildRestoreMap (RestoreAssemblyResources, InputReferencePaths, CancelToken);
 			if (restoreMap == null)
 				return false;
 
@@ -48,8 +48,7 @@ namespace Xamarin.Build.Download
 
 				// We only want to find proguard files in .aar files referenced
 				// for assemblies we actually have referenced and have them mapped to
-				var asmName = new AssemblyName (asm.Key);
-				ITaskItem item = FindMatchingAssembly (InputReferencePaths, asmName);
+				ITaskItem item = asm.Value.InputAssemblyReference;
 				if (item == null) {
 					if (ThrowOnMissingAssembly)
 						return false;
@@ -58,7 +57,7 @@ namespace Xamarin.Build.Download
 				}
 
 				// Use a hash for the assembly name to keep paths shorter
-				var saveNameHash = DownloadUtils.HashMd5 (asmName.Name)?.Substring (0, 8);
+				var saveNameHash = DownloadUtils.HashMd5 (asm.Value.CanonicalName.Name)?.Substring (0, 8);
 
 				// We keep a stamp file around to avoid reprocessing, so skip if it exists
 				var stampPath = Path.Combine (outputDir, saveNameHash + ".proguard.stamp");
@@ -66,7 +65,7 @@ namespace Xamarin.Build.Download
 					continue;
 
 				// Get all the mapped .aar files
-				var resourceItems = asm.Value;
+				var resourceItems = asm.Value.RestoreItems;
 
 				// We want to increment on the hash name in case there are multiple .aar files and/or proguard config
 				// files for a given assembly, so we use them all and not overwrite the same name

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
@@ -76,5 +76,10 @@ namespace Xamarin.Build.Download
 		{
 			base.Log.LogErrorFromException (exception);
 		}
+
+        public void LogMessage (string message, params object[] param)
+        {
+            base.Log.LogMessage(message, param);
+        }
 	}
 }

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Build.Download
 			}
 
 			var lockFile = xbd.DestinationDir + ".locked";
-			using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, Token, TimeSpan.FromSeconds (xbd.ExclusiveLockTimeout), this)) {
+			using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, Token, TimeSpan.FromSeconds (xbd.ExclusiveLockTimeout), Log)) {
 
 				if (lockStream == null) {
 					LogCodedError (ErrorCodes.ExclusiveLockTimeout, "Timed out waiting for exclusive file lock on: {0}", lockFile);

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Build.Download
 					// Since we could download a multipart request, we are locking on the url from any other process downloading from it
 					var lockFile = Path.Combine (cacheDirectory, DownloadUtils.HashMd5 (downloadUrl) + ".locked");
 
-					using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, base.Token, TimeSpan.FromSeconds (30))) {
+					using (var lockStream = DownloadUtils.ObtainExclusiveFileLock (lockFile, base.Token, TimeSpan.FromSeconds (30), Log)) {
 
 						if (lockStream == null) {
 							LogCodedError (ErrorCodes.ExclusiveLockTimeout, "Timed out waiting for exclusive file lock on: {0}", lockFile);

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/packages.config
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
+  <package id="Mono.Cecil" version="0.10.0-beta7" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
First big change is loading up and caching the `AssemblyName.GetAssemblyName(..)` calls in each execution of the task.  It should happen now in the `BuildRestoreMap` call once per task execution, and will also try to cache the results with the global build engine for parallel executions to utilize.  It also locks around the reading of the assembly name from file, as well as trying multiple times before failing.

The other big change is surrounding the access to the assembly for merging resources in an exclusive file lock, with some global build engine state gating too.

First we check to see if any other task instance has processed the assembly already, and then we try to open an exclusive lock on the .lock file for that output assembly.  If another task is already processing we will wait for a lock, and once we get the lock (the other task finished) we check the global build cache once more as it’s likely the other task already did what we were trying to do.