### PR TITLE
[xbd] Try alternate 7zip path on windows for 15.7+

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.9</version>
+    <version>0.4.10</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865061</projectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -47,6 +47,8 @@
 
 		<PropertyGroup>
 			<XamarinBuildDownloadUser7ZipPath Condition="'$(OS)'!='Unix' and '$(XamarinBuildDownloadUser7ZipPath)'==''">$(VsInstallRoot)\Common7\IDE\Extensions\Xamarin.VisualStudio\7-Zip\7z.exe</XamarinBuildDownloadUser7ZipPath>
+			<!-- VS2017 15.7+ moves 7zip -->
+			<XamarinBuildDownloadUser7ZipPath Condition="'$(OS)'!='Unix' and !Exists('$(XamarinBuildDownloadUser7ZipPath)')">$(VsInstallRoot)\Common7\IDE\Extensions\Xamarin\VisualStudio\7-Zip\7z.exe</XamarinBuildDownloadUser7ZipPath>
 		</PropertyGroup>
 
 		<XamarinDownloadArchives


### PR DESCRIPTION
As of VS2017 15.7+ 7zip is moved slightly.  It now exists in `Common7\IDE\Extensions\Xamarin\VisualStudio\7-Zip\` instead of `Common7\IDE\Extensions\Xamarin.VisualStudio\7-Zip` as in older versions.