### PR TITLE
Fix #355 [OpenID] Update TokenResponse parameters to use INSCopying

### DIFF
--- a/XPlat/OpenId/build.cake
+++ b/XPlat/OpenId/build.cake
@@ -49,9 +49,9 @@ var buildSpec = new BuildSpec {
 		new DefaultSolutionBuilder { SolutionPath = "./Android/samples/OpenIdAuthSampleAndroid.sln" }
 	},
 
-	// Components = new [] {
-	// 	new Component { ManifestDirectory = "./component" }
-	// }
+	Components = new [] {
+		new Component { ManifestDirectory = "./component" }
+	}
 };
 
 Task ("externals-android")

--- a/XPlat/OpenId/iOS/source/OpenId.AppAuth.iOS/ApiDefinition.cs
+++ b/XPlat/OpenId/iOS/source/OpenId.AppAuth.iOS/ApiDefinition.cs
@@ -952,12 +952,12 @@ namespace OpenId.AppAuth
 
 		// @property (readonly, nonatomic) NSDictionary<NSString *,NSObject<NSCopying> *> * _Nullable additionalParameters;
 		[NullAllowed, Export("additionalParameters")]
-		NSDictionary<NSString, NSCopying> AdditionalParameters { get; }
+		NSDictionary<NSString, INSCopying> AdditionalParameters { get; }
 
 		// -(instancetype _Nonnull)initWithRequest:(OIDTokenRequest * _Nonnull)request parameters:(NSDictionary<NSString *,NSObject<NSCopying> *> * _Nonnull)parameters __attribute__((objc_designated_initializer));
 		[Export("initWithRequest:parameters:")]
 		[DesignatedInitializer]
-		IntPtr Constructor(TokenRequest request, NSDictionary<NSString, NSCopying> parameters);
+		IntPtr Constructor(TokenRequest request, NSDictionary<NSString, INSCopying> parameters);
 	}
 
 	interface IAuthorizationUICoordinator { }


### PR DESCRIPTION
## Motivation
As mentioned in #355 when trying to create an instance of `TokenResponse` for testing purposes the `parameters` parameter expects a value of type `NSDictionary<NSString, NSCopying>`. I believe this is meant to be `NSDictionary<NSString, INSCopying>` as this is the interface/protocol that the iOS AppAuth SDK refers to. `NSCopying` in Xamarin is an implementation of this interface/protocol.

## Description
Change `NSDictionary<NSString, NSCopying>` to `NSDictionary<NSString, INSCopying>` for parameters in `TokenResponse.`

Resolves #355 