### PR TITLE
Mapbox SDK - Implement missing constructor for MGLRasterStyleLayer class

### DIFF
--- a/XPlat/Mapbox/iOS/source/MapboxSDK.iOS/ApiDefinition.cs
+++ b/XPlat/Mapbox/iOS/source/MapboxSDK.iOS/ApiDefinition.cs
@@ -2380,6 +2380,10 @@ namespace Mapbox
     [BaseType(typeof(ForegroundStyleLayer), Name = "MGLRasterStyleLayer")]
     interface RasterStyleLayer
     {
+        // -(instancetype _Nonnull)initWithIdentifier:(NSString * _Nonnull)identifier source:(MGLSource * _Nonnull)source;
+        [Export("initWithIdentifier:source:")]
+        IntPtr Constructor(string identifier, Source source);
+
         // @property (nonatomic) MGLStyleValue<NSNumber *> * _Null_unspecified maximumRasterBrightness;
         [Export ("maximumRasterBrightness", ArgumentSemantic.Assign)]
         StyleValue MaximumRasterBrightness { get; set; }


### PR DESCRIPTION
Fix for issue #359 