### PR TITLE
[xbd] Fix errors with partial zip downloads

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.10</version>
+    <version>0.4.11</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865061</projectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -56,7 +56,7 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Formatting">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
@@ -121,50 +121,21 @@ namespace Xamarin.Build.Download
 
 		async Task Download (string cacheDirectory, string url, List<PartialZipDownload> parts)
 		{
-			var req = new HttpRequestMessage (HttpMethod.Get, url);
-
-			// This seems to fix a weird issue where killing the connection on mono on macOS
-			// causes the request to hang indefinitely
-			req.Headers.ConnectionClose = true;
-
 			HttpResponseMessage resp;
 
-			// If we have a single item, we can't process the response as multipart since 
-			// our response will not include multipart boundaries
-			if (parts.Count == 1) {
-				var singlePart = parts.First ();
-				req.Headers.Range = new RangeHeaderValue (singlePart.RangeStart, singlePart.RangeEnd);
+			foreach (var part in parts) {
+				var req = new HttpRequestMessage (HttpMethod.Get, url);
+
+				// This seems to fix a weird issue where killing the connection on mono on macOS
+				// causes the request to hang indefinitely
+				req.Headers.ConnectionClose = true;
+
+				req.Headers.Range = new RangeHeaderValue (part.RangeStart, part.RangeEnd);
 
 				resp = await http.SendAsync (req).ConfigureAwait (false);
 
 				using (var partStream = await resp.Content.ReadAsStreamAsync ().ConfigureAwait (false))
-					await ExtractPartAndValidate (singlePart, partStream, cacheDirectory).ConfigureAwait (false);
-
-			} else {
-				// For Multiple ranges, we'll add multiple header values
-				// and expect back an actual multipart data response
-				req.Headers.Range = new RangeHeaderValue ();
-				foreach (var part in parts)
-					req.Headers.Range.Ranges.Add (new RangeItemHeaderValue (part.RangeStart, part.RangeEnd));
-
-				resp = await http.SendAsync (req).ConfigureAwait (false);
-
-				var multiparts = await resp.Content.ReadAsMultipartAsync ();
-				//var multiparts = await resp.Content.ReadAsMultiPartContentAsync ().ConfigureAwait (false);
-
-				foreach (var mpart in multiparts.Contents) {
-					var part = parts.FirstOrDefault (p => p.RangeStart == mpart.Headers.ContentRange.From.Value
-													 && p.RangeEnd == mpart.Headers.ContentRange.To.Value);
-
-					if (part == null)
-						continue;
-
-					LogMessage ("Extracting and Validating Part: {0} [{1}-{2}]", part.Id, part.RangeStart, part.RangeEnd);
-
-					//using (var partStream = new MemoryStream (mpart.ReadAsStreamAsync ()))
-					using (var partStream = await mpart.ReadAsStreamAsync ().ConfigureAwait (false))
-						await ExtractPartAndValidate (part, partStream, cacheDirectory).ConfigureAwait (false);
-				}
+					await ExtractPartAndValidate (part, partStream, cacheDirectory).ConfigureAwait (false);
 			}
 		}
 

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/packages.config
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Previously we were requesting multiple ranges in a single request, which now seems unreliable.  This changes to using a single http request for each part, while still specifying a requested range for only the part of the zip file needed.

Also updated nuget dependency