### PR TITLE
[mono.apitools] Updated the package to include the Mono.ApiTools libraries

### DIFF
--- a/XPlat/Mono.ApiTools/build.cake
+++ b/XPlat/Mono.ApiTools/build.cake
@@ -3,12 +3,12 @@
 
 var TARGET = Argument("t", Argument("target", "Default"));
 
-var MONO_TAG = "ffe4e3f7878fb1980a620f377d64a6129ab6a4ce";
+var MONO_TAG = "c32af8905b5d672f58acad6fc9e08bf61375b850";
 
 var ASSEMBLY_VERSION = "5.0.0.0";
 var ASSEMBLY_FILE_VERSION = "5.14.0.0";
 var ASSEMBLY_INFO_VERSION = "5.14.0.0";
-var NUGET_VERSION = "5.14.0";
+var NUGET_VERSION = "5.14.0.1";
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
 
@@ -40,10 +40,14 @@ Task("libs")
 		.WithProperty("FileVersion", ASSEMBLY_FILE_VERSION)
 		.WithProperty("InformationalVersion", ASSEMBLY_INFO_VERSION));
 
-	var outDir = OUTPUT_PATH.Combine("tools");
-	EnsureDirectoryExists(outDir);
-	CopyFiles("source/*/bin/Release/*/*.dll", outDir);
-	CopyFiles("source/*/bin/Release/*/*.exe", outDir);
+	var toolsDir = OUTPUT_PATH.Combine("tools");
+	EnsureDirectoryExists(toolsDir);
+	CopyFiles("source/mono-api-*/bin/Release/*/*.dll", toolsDir);
+	CopyFiles("source/mono-api-*/bin/Release/*/*.exe", toolsDir);
+
+	var libDir = OUTPUT_PATH.Combine("lib");
+	EnsureDirectoryExists(libDir);
+	CopyFiles("source/Mono.ApiTools.*/bin/Release/*/*.dll", libDir);
 });
 
 Task("nuget")

--- a/XPlat/Mono.ApiTools/nuget/Mono.ApiTools.nuspec
+++ b/XPlat/Mono.ApiTools/nuget/Mono.ApiTools.nuspec
@@ -11,9 +11,13 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>A set of tools to help with .NET API development and diff-ing.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-    <tags>mono-api-tools, mono-api-info, mono-api-diff, mono-api-html</tags>
+    <tags>mono-api-tools, mono-api-info, mono-api-diff, mono-api-html, aoi information, diff, compare, html, xml, markdown</tags>
+    <dependencies>
+      <dependency id="Mono.Cecil" version="0.10.0" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="output\tools\**\*.*" target="tools" />
+    <file src="output\lib\*.dll" target="lib\netstandard2.0" />
+    <file src="output\tools\*.*" target="tools" />
   </files>
 </package>

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiff/Mono.ApiTools.ApiDiff.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiff/Mono.ApiTools.ApiDiff.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../externals/mono-api-diff/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiffFormatted/Mono.ApiTools.ApiDiffFormatted.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiffFormatted/Mono.ApiTools.ApiDiffFormatted.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../../externals/mono-api-html/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiInfo/Mono.ApiTools.ApiInfo.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiInfo/Mono.ApiTools.ApiInfo.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../externals/mono-api-info/*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/XPlat/Mono.ApiTools/source/mono-api-tools.sln
+++ b/XPlat/Mono.ApiTools/source/mono-api-tools.sln
@@ -3,19 +3,22 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mono-api-info", "mono-api-info\mono-api-info.csproj", "{82A42CF4-F381-4235-8FBA-2DF3AFD9895F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mono-api-info", "mono-api-info\mono-api-info.csproj", "{82A42CF4-F381-4235-8FBA-2DF3AFD9895F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mono-api-diff", "mono-api-diff\mono-api-diff.csproj", "{6D5FA521-134A-4986-BCE4-0DBF24E130F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mono-api-diff", "mono-api-diff\mono-api-diff.csproj", "{6D5FA521-134A-4986-BCE4-0DBF24E130F5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mono-api-html", "mono-api-html\mono-api-html.csproj", "{14DE355B-E0D7-403F-BD94-91FFB4972CC0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mono-api-html", "mono-api-html\mono-api-html.csproj", "{14DE355B-E0D7-403F-BD94-91FFB4972CC0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.ApiTools.ApiDiff", "Mono.ApiTools.ApiDiff\Mono.ApiTools.ApiDiff.csproj", "{0E6715C4-0C54-4063-8A28-710B73AE0C9E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.ApiTools.ApiDiffFormatted", "Mono.ApiTools.ApiDiffFormatted\Mono.ApiTools.ApiDiffFormatted.csproj", "{20171912-FF8A-461A-8685-A743E438CB3D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.ApiTools.ApiInfo", "Mono.ApiTools.ApiInfo\Mono.ApiTools.ApiInfo.csproj", "{4D762D48-355E-4E3D-AE45-C1F0193A0CEE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{82A42CF4-F381-4235-8FBA-2DF3AFD9895F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -30,5 +33,23 @@ Global
 		{14DE355B-E0D7-403F-BD94-91FFB4972CC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{14DE355B-E0D7-403F-BD94-91FFB4972CC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{14DE355B-E0D7-403F-BD94-91FFB4972CC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E6715C4-0C54-4063-8A28-710B73AE0C9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E6715C4-0C54-4063-8A28-710B73AE0C9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E6715C4-0C54-4063-8A28-710B73AE0C9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E6715C4-0C54-4063-8A28-710B73AE0C9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20171912-FF8A-461A-8685-A743E438CB3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20171912-FF8A-461A-8685-A743E438CB3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20171912-FF8A-461A-8685-A743E438CB3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20171912-FF8A-461A-8685-A743E438CB3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D762D48-355E-4E3D-AE45-C1F0193A0CEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D762D48-355E-4E3D-AE45-C1F0193A0CEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D762D48-355E-4E3D-AE45-C1F0193A0CEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D762D48-355E-4E3D-AE45-C1F0193A0CEE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {22023CAE-F851-485A-85F4-0E29E28AD064}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This is the update with all the changes from github.com/mono/mono/pull/9793

## Changes
 - bugfix for nested interfaces not being added to the API info
 - the tools can now be used as a set of libraries within other libraries or apps
 - a few more options that make generating APIs easier