### PR TITLE
[xbd] don’t package aapt/AndroidManifest.xml

### DIFF
--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.11</version>
+    <version>0.4.12</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865061</projectUrl>

--- a/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
+++ b/Util/Xamarin.Build.Download/nuget/Xamarin.Build.Download.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Build.Download</id>
     <title>Xamarin Build-time Download Support</title>
-    <version>0.4.12</version>
+    <version>0.4.12-preview</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865061</projectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarRestore.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildAndroidAarRestore.cs
@@ -35,6 +35,13 @@ namespace Xamarin.Build.Download
 					// Open the old entry
 					var oldEntry = zipArchive.GetEntry (entryName);
 
+					// Some .aars contain an AndroidManifest.xml in the aapt folder which is essentially a duplicate of the main one
+					// but a sanitized version with placeholders like ${applicationId} being escaped to _dollar blah
+					// we don't care about these for xamarin.android, which picks up both manifests and merges both
+					// This will ensure the 'sanitized' version doesn't get packaged
+					if (oldEntry.Name.TrimStart ('/').Equals ("aapt/AndroidManifest.xml", StringComparison.InvariantCultureIgnoreCase))
+						continue;
+
 					// We are only re-adding non empty folders, otherwise we end up with a corrupt zip in mono
 					if (!string.IsNullOrEmpty (oldEntry.Name)) {
 


### PR DESCRIPTION
Some .aars contain an AndroidManifest.xml in the aapt folder which is essentially a duplicate of the main one but a sanitized version with placeholders like ${applicationId} being escaped to _dollar blah we don't care about these for xamarin.android, which picks up both manifests and merges both This will ensure the 'sanitized' version doesn't get packaged at least until xamarin.android can release a fix.

This should help with #444 
