### PR TITLE
[mono-api-tools] Add a net45 framework assembly to help when using cake

### DIFF
--- a/XPlat/Mono.ApiTools/build.cake
+++ b/XPlat/Mono.ApiTools/build.cake
@@ -8,7 +8,7 @@ var MONO_TAG = "c32af8905b5d672f58acad6fc9e08bf61375b850";
 var ASSEMBLY_VERSION = "5.0.0.0";
 var ASSEMBLY_FILE_VERSION = "5.14.0.0";
 var ASSEMBLY_INFO_VERSION = "5.14.0.0";
-var NUGET_VERSION = "5.14.0.1";
+var NUGET_VERSION = "5.14.0.2";
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
 
@@ -45,9 +45,13 @@ Task("libs")
 	CopyFiles("source/mono-api-*/bin/Release/*/*.dll", toolsDir);
 	CopyFiles("source/mono-api-*/bin/Release/*/*.exe", toolsDir);
 
-	var libDir = OUTPUT_PATH.Combine("lib");
+	var libDir = OUTPUT_PATH.Combine("lib/netstandard2.0");
 	EnsureDirectoryExists(libDir);
-	CopyFiles("source/Mono.ApiTools.*/bin/Release/*/*.dll", libDir);
+	CopyFiles("source/Mono.ApiTools.*/bin/Release/netstandard2.0/Mono.ApiTools.*.dll", libDir);
+
+	libDir = OUTPUT_PATH.Combine("lib/net45");
+	EnsureDirectoryExists(libDir);
+	CopyFiles("source/Mono.ApiTools.*/bin/Release/net45/Mono.ApiTools.*.dll", libDir);
 });
 
 Task("nuget")

--- a/XPlat/Mono.ApiTools/nuget/Mono.ApiTools.nuspec
+++ b/XPlat/Mono.ApiTools/nuget/Mono.ApiTools.nuspec
@@ -17,7 +17,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output\lib\*.dll" target="lib\netstandard2.0" />
+    <file src="output\lib\netstandard2.0\*.dll" target="lib\netstandard2.0" />
+    <file src="output\lib\net45\*.dll" target="lib\net45" />
     <file src="output\tools\*.*" target="tools" />
   </files>
 </package>

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiff/Mono.ApiTools.ApiDiff.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiff/Mono.ApiTools.ApiDiff.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
   </PropertyGroup>
 

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiffFormatted/Mono.ApiTools.ApiDiffFormatted.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiDiffFormatted/Mono.ApiTools.ApiDiffFormatted.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
   </PropertyGroup>
 

--- a/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiInfo/Mono.ApiTools.ApiInfo.csproj
+++ b/XPlat/Mono.ApiTools/source/Mono.ApiTools.ApiInfo/Mono.ApiTools.ApiInfo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EXCLUDE_DRIVER</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
This was mainly for the case where you are using a net45/net46 system which does not yet support netstandard2.0.