### PR TITLE
[MaterialComponents] Added some overloads to help alleviate the type changes since v60

### DIFF
--- a/iOS/MaterialComponents/source/MaterialComponents/ApiDefinition.cs
+++ b/iOS/MaterialComponents/source/MaterialComponents/ApiDefinition.cs
@@ -778,6 +778,11 @@ namespace MaterialComponents {
 		[Export ("applySurfaceVariantWithSemanticColorScheme:toBottomAppBarView:")]
 		void ApplySurfaceVariant (IColorScheming colorScheme, BottomAppBarView bottomAppBarView);
 
+		[Static]
+		[Wrap ("ApplySurfaceVariant (colorScheme, bottomAppBarView)")]
+		[Obsolete ("Use ApplySurfaceVariant instead.")]
+		void ApplySurfaceVariantWithSemanticColorScheme (IColorScheming colorScheme, BottomAppBarView bottomAppBarView);
+
 		//
 		// From MDCBottomAppBarColorThemer (ToBeDeprecated)
 		//
@@ -1410,6 +1415,9 @@ namespace MaterialComponents {
 		// -(MDCShadowElevation)elevationForState:(UIControlState)state;
 		[Export ("elevationForState:")]
 		nfloat GetElevation (UIControlState state);
+		
+		[Wrap ("SetElevation ((nfloat)elevation, state)")]
+		void SetElevation (double elevation, UIControlState state);
 
 		// -(void)setElevation:(MDCShadowElevation)elevation forState:(UIControlState)state;
 		[Export ("setElevation:forState:")]
@@ -1697,6 +1705,9 @@ namespace MaterialComponents {
 		[Export ("setShadowElevation:forState:")]
 		void SetShadowElevation (nfloat shadowElevation, UIControlState state);
 
+		[Wrap ("SetShadowElevation ((nfloat)shadowElevation, state)")]
+		void SetShadowElevation (double shadowElevation, UIControlState state);
+
 		// -(MDCShadowElevation)shadowElevationForState:(UIControlState)state __attribute__((annotate("ui_appearance_selector")));
 		[Export ("shadowElevationForState:")]
 		nfloat GetShadowElevation (UIControlState state);
@@ -1760,6 +1771,9 @@ namespace MaterialComponents {
 		// -(void)setShadowElevation:(MDCShadowElevation)shadowElevation forState:(MDCCardCellState)state __attribute__((annotate("ui_appearance_selector")));
 		[Export ("setShadowElevation:forState:")]
 		void SetShadowElevation (nfloat shadowElevation, CardCellState state);
+		
+		[Wrap ("SetShadowElevation ((nfloat)shadowElevation, state)")]
+		void SetShadowElevation (double shadowElevation, CardCellState state);
 
 		// -(MDCShadowElevation)shadowElevationForState:(MDCCardCellState)state __attribute__((annotate("ui_appearance_selector")));
 		[Export ("shadowElevationForState:")]
@@ -1850,7 +1864,7 @@ namespace MaterialComponents {
 	[BaseType (typeof (NSObject), Name = "MDCCardScheme")]
 	interface CardScheme : CardScheming {
 		// @property (readwrite, nonatomic) MDCSemanticColorScheme * _Nonnull colorScheme;
-		[Export("colorScheme", ArgumentSemantic.Assign)]
+		[Export ("colorScheme", ArgumentSemantic.Assign)]
 		new IColorScheming ColorScheme { get; set; }
 
 		// @property (readwrite, nonatomic) MDCShapeScheme * _Nonnull shapeScheme;
@@ -2184,6 +2198,9 @@ namespace MaterialComponents {
 		[Export ("setElevation:forState:")]
 		void SetElevation (nfloat elevation, UIControlState state);
 
+		[Wrap ("SetElevation ((nfloat)elevation, state)")]
+		void SetElevation (double elevation, UIControlState state);
+
 		// -(UIColor * _Nullable)inkColorForState:(UIControlState)state;
 		[return: NullAllowed]
 		[Export ("inkColorForState:")]
@@ -2312,7 +2329,7 @@ namespace MaterialComponents {
 	interface ChipViewShapeThemer {
 		// +(void)applyShapeScheme:(id<MDCShapeScheming> _Nonnull)shapeScheme toChipView:(MDCChipView * _Nonnull)chipView;
 		[Static]
-		[Export("applyShapeScheme:toChipView:")]
+		[Export ("applyShapeScheme:toChipView:")]
 		void ApplyShapeScheme(IShapeScheming shapeScheme, ChipView chipView);
 	}
 
@@ -5636,6 +5653,9 @@ namespace MaterialComponents {
 		[Export ("initWithFrame:shapeGenerator:")]
 		[DesignatedInitializer]
 		IntPtr Constructor (CGRect frame, [NullAllowed] IShapeGenerating shapeGenerator);
+
+		[Wrap ("this (frame, null)")]
+		IntPtr Constructor (CGRect frame);
 	}
 
 	interface IShapeGenerating { }
@@ -6502,15 +6522,29 @@ namespace MaterialComponents {
 		[Export ("applySemanticColorScheme:toTextInputController:")]
 		void ApplySemanticColorScheme (IColorScheming colorScheme, ITextInputController textInputController);
 
+		[Static]
+		[Wrap ("ApplySemanticColorScheme (colorScheme, textInputController)")]
+		[Obsolete ("Use ApplySemanticColorScheme instead.")]
+		void ApplySemanticColorSchemeToTextInputController (IColorScheming colorScheme, ITextInputController textInputController);
+
 		// +(void)applySemanticColorScheme:(id<MDCColorScheming> _Nonnull)colorScheme toAllTextInputControllersOfClass:(Class<MDCTextInputController> _Nonnull)textInputControllerClass;
 		[Static]
 		[Export ("applySemanticColorScheme:toAllTextInputControllersOfClass:")]
 		void ApplySemanticColorSchemeToAll (IColorScheming colorScheme, Class textInputControllerClass);
 
+		[Static]
+		[Wrap ("ApplySemanticColorSchemeToAll (colorScheme, new Class (textInputControllerType))")]
+		void ApplySemanticColorSchemeToAll (IColorScheming colorScheme, Type textInputControllerType);
+
 		// +(void)applySemanticColorScheme:(id<MDCColorScheming> _Nonnull)colorScheme toTextInput:(id<MDCTextInput> _Nonnull)textInput;
 		[Static]
 		[Export ("applySemanticColorScheme:toTextInput:")]
 		void ApplySemanticColorScheme (IColorScheming colorScheme, ITextInput textInput);
+
+		[Static]
+		[Wrap ("ApplySemanticColorScheme (colorScheme, textInput)")]
+		[Obsolete ("Use ApplySemanticColorScheme instead.")]
+		void ApplySemanticColorSchemeToTextInput (IColorScheming colorScheme, ITextInput textInput);
 
 		// +(void)applyColorScheme:(id<MDCColorScheme> _Nonnull)colorScheme toTextInputController:(id<MDCTextInputController> _Nonnull)textInputController;
 		[Obsolete ("This method will soon be deprecated. Consider using ApplySemanticColorScheme method instead.")]
@@ -6534,16 +6568,30 @@ namespace MaterialComponents {
 		[Static]
 		[Export ("applyFontScheme:toTextInputController:")]
 		void ApplyFontScheme (IFontScheme fontScheme, ITextInputController textInputController);
+		
+		[Static]
+		[Wrap ("ApplyFontScheme (fontScheme, textInputController)")]
+		[Obsolete ("Use ApplyFontScheme instead.")]
+		void ApplyFontSchemeToTextInputController (IFontScheme fontScheme, ITextInputController textInputController);
 
 		// +(void)applyFontScheme:(id<MDCFontScheme> _Nonnull)fontScheme toAllTextInputControllersOfClass:(Class<MDCTextInputController> _Nonnull)textInputControllerClass;
 		[Static]
 		[Export ("applyFontScheme:toAllTextInputControllersOfClass:")]
 		void ApplyFontSchemeToAll (IFontScheme fontScheme, Class textInputControllerClass);
+		
+		[Static]
+		[Wrap ("ApplyFontSchemeToAll (fontScheme, new Class (textInputControllerType))")]
+		void ApplyFontSchemeToAll (IFontScheme fontScheme, Type textInputControllerType);
 
 		// +(void)applyFontScheme:(id<MDCFontScheme> _Nonnull)fontScheme toTextField:(MDCTextField * _Nullable)textField;
 		[Static]
 		[Export ("applyFontScheme:toTextField:")]
 		void ApplyFontScheme (IFontScheme fontScheme, [NullAllowed] TextField textField);
+
+		[Static]
+		[Wrap ("ApplyFontScheme (fontScheme, textField)")]
+		[Obsolete ("Use ApplyFontScheme instead.")]
+		void ApplyFontSchemeToTextField (IFontScheme fontScheme, TextField textField);
 	}
 
 	interface ITextInputPositioningDelegate { }
@@ -6599,11 +6647,25 @@ namespace MaterialComponents {
 		[Static]
 		[Export ("applyTypographyScheme:toAllTextInputControllersOfClass:")]
 		void ApplyTypographySchemeToAll (ITypographyScheming typographyScheme, Class textInputControllerClass);
+		
+		[Static]
+		[Wrap ("ApplyTypographySchemeToAll (typographyScheme, new Class (textInputControllerType))")]
+		void ApplyTypographySchemeToAll (ITypographyScheming typographyScheme, Type textInputControllerType);
 
 		// +(void)applyTypographyScheme:(id<MDCTypographyScheming> _Nonnull)typographyScheme toTextInput:(id<MDCTextInput> _Nonnull)textInput;
 		[Static]
 		[Export ("applyTypographyScheme:toTextInput:")]
 		void ApplyTypographyScheme (ITypographyScheming typographyScheme, ITextInput textInput);
+
+		[Static]
+		[Wrap ("ApplyTypographyScheme (typographyScheme, textInputController)")]
+		[Obsolete ("Use ApplyTypographyScheme instead.")]
+		void ApplyTypographySchemeToTextInputController (ITypographyScheming typographyScheme, ITextInputController textInputController);
+
+		[Static]
+		[Wrap ("ApplyTypographyScheme (typographyScheme, textInput)")]
+		[Obsolete ("Use ApplyTypographyScheme instead.")]
+		void ApplyTypographySchemeToTextInput (ITypographyScheming typographyScheme, ITextInput textInput);
 	}
 
 	interface ITextInput { }

--- a/iOS/MaterialComponents/source/MaterialComponents/Extensions.cs
+++ b/iOS/MaterialComponents/source/MaterialComponents/Extensions.cs
@@ -93,6 +93,30 @@ namespace MaterialComponents {
 		}
 	}
 
+	partial class Card {
+		public void SetShadowElevation (double shadowElevation, UIControlState state) {
+			SetShadowElevation ((nfloat)shadowElevation, state);
+		}
+	}
+
+	partial class CardCollectionCell {
+		public void SetShadowElevation (double shadowElevation, CardCellState state) {
+			SetShadowElevation ((nfloat)shadowElevation, state);
+		}
+	}
+
+	partial class ChipView {
+		public void SetElevation (double elevation, UIControlState state) {
+			SetElevation ((nfloat)elevation, state);
+		}
+	}
+
+	partial class Button {
+		public void SetElevation (double elevation, UIControlState state) {
+			SetElevation ((nfloat)elevation, state);
+		}
+	}
+
 	partial class TextFieldColorThemer {
 		public static void ApplySemanticColorSchemeToAll (IColorScheming colorScheme, Type textInputControllerType) {
 			ApplySemanticColorSchemeToAll (colorScheme, new Class (textInputControllerType));

--- a/iOS/MaterialComponents/source/MaterialComponents/Extensions.cs
+++ b/iOS/MaterialComponents/source/MaterialComponents/Extensions.cs
@@ -80,104 +80,27 @@ namespace MaterialComponents {
 		public static readonly nfloat Switch = (nfloat)1.0;
 	}
 
-	partial class ShapedView {
-		public ShapedView (CGRect frame) : this (frame, null) {
-		}
-	}
-
-	partial class BottomAppBarColorThemer {
-		// renamed/obsolete members
-		[Obsolete ("Use ApplySurfaceVariant instead.")]
-		public static void ApplySurfaceVariantWithSemanticColorScheme (IColorScheming colorScheme, BottomAppBarView bottomAppBarView) {
-			ApplySurfaceVariant (colorScheme, bottomAppBarView);
-		}
-	}
-
-	partial class Card {
-		public void SetShadowElevation (double shadowElevation, UIControlState state) {
-			SetShadowElevation ((nfloat)shadowElevation, state);
-		}
-	}
-
-	partial class CardCollectionCell {
-		public void SetShadowElevation (double shadowElevation, CardCellState state) {
-			SetShadowElevation ((nfloat)shadowElevation, state);
-		}
-	}
-
-	partial class ChipView {
-		public void SetElevation (double elevation, UIControlState state) {
-			SetElevation ((nfloat)elevation, state);
-		}
-	}
-
-	partial class Button {
-		public void SetElevation (double elevation, UIControlState state) {
-			SetElevation ((nfloat)elevation, state);
-		}
-	}
-
 	partial class TextFieldColorThemer {
-		public static void ApplySemanticColorSchemeToAll (IColorScheming colorScheme, Type textInputControllerType) {
-			ApplySemanticColorSchemeToAll (colorScheme, new Class (textInputControllerType));
-		}
 		public static void ApplySemanticColorSchemeToAll<T> (IColorScheming colorScheme) where T : ITextInputController {
 			ApplySemanticColorSchemeToAll (colorScheme, typeof (T));
-		}
-
-		// renamed/obsolete members
-		[Obsolete ("Use ApplySemanticColorScheme instead.")]
-		public static void ApplySemanticColorSchemeToTextInputController (IColorScheming colorScheme, ITextInputController textInputController) {
-			ApplySemanticColorScheme (colorScheme, textInputController);
-		}
-		[Obsolete ("Use ApplySemanticColorScheme instead.")]
-		public static void ApplySemanticColorSchemeToTextInput (IColorScheming colorScheme, ITextInput textInput) {
-			ApplySemanticColorScheme (colorScheme, textInput);
 		}
 	}
 
 	partial class TextFieldFontThemer {
-		public static void ApplyFontSchemeToAll (IFontScheme fontScheme, Type textInputControllerType) {
-			ApplyFontSchemeToAll (fontScheme, new Class (textInputControllerType));
-		}
 		public static void ApplyFontSchemeToAll<T> (IFontScheme fontScheme) where T : ITextInputController {
 			ApplyFontSchemeToAll (fontScheme, typeof (T));
-		}
-
-		// renamed/obsolete members
-		[Obsolete ("Use ApplyFontScheme instead.")]
-		public static void ApplyFontSchemeToTextInputController (IFontScheme fontScheme, ITextInputController textInputController) {
-			ApplyFontScheme (fontScheme, textInputController);
-		}
-		[Obsolete ("Use ApplyFontScheme instead.")]
-		public static void ApplyFontSchemeToTextField (IFontScheme fontScheme, TextField textField) {
-			ApplyFontScheme (fontScheme, textField);
 		}
 	}
 	
 	partial class TextFieldTypographyThemer {
-		public static void ApplyTypographySchemeToAll (ITypographyScheming typographyScheme, Type textInputControllerType) {
-			ApplyTypographySchemeToAll (typographyScheme, new Class (textInputControllerType));
-		}
 		public static void ApplyTypographySchemeToAll<T> (ITypographyScheming typographyScheme) where T : ITextInputController {
 			ApplyTypographySchemeToAll (typographyScheme, typeof (T));
-		}
-
-		// renamed/obsolete members
-		[Obsolete ("Use ApplyTypographyScheme instead.")]
-		public static void ApplyTypographySchemeToTextInputController (ITypographyScheming typographyScheme, ITextInputController textInputController) {
-			ApplyTypographyScheme (typographyScheme, textInputController);
-		}
-		[Obsolete ("Use ApplyTypographyScheme instead.")]
-		public static void ApplyTypographySchemeToTextInput (ITypographyScheming typographyScheme, ITextInput textInput) {
-			ApplyTypographyScheme (typographyScheme, textInput);
 		}
 	}
 
 	partial class CAMediaTimingFunctionAnimationTiming {
 		[CompilerGenerated]
 		static readonly IntPtr class_ptr = Class.GetHandle ("CAMediaTimingFunction");
-
 	}
 
 	public static partial class MaterialComponentsConstants {


### PR DESCRIPTION
Added some overloads to help alleviate the type changes since v60:
 - the type used for elevation was changed to `nfloat`, so I added back the original methods for `double`
 - some properties and getter methods are still "broken", but that is harder to fix as the return type changed

The most notable bug so far is this on: https://github.com/xamarin/Xamarin.Forms/issues/5021