### PR TITLE
Add option to copy all  /**/output/* to a root dir

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -8,7 +8,7 @@ var TARGET = Argument ("target", Argument ("t", Argument ("Target", "build")));
 var GIT_PREVIOUS_COMMIT = EnvironmentVariable ("GIT_PREVIOUS_SUCCESSFUL_COMMIT") ?? Argument ("gitpreviouscommit", "");
 var GIT_COMMIT = EnvironmentVariable ("GIT_COMMIT") ?? Argument("gitcommit", "");
 var GIT_BRANCH = EnvironmentVariable ("GIT_BRANCH") ?? "origin/master";
-var GIT_PATH = EnvironmentVariable ("GIT_EXE") ?? (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Git\\bin\\git.exe" : "git");
+var GIT_PATH = EnvironmentVariable ("GIT_EXE") ?? Argument("gitexe", (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Git\\bin\\git.exe" : "git"));
 
 var BUILD_GROUPS = DeserializeYamlFromFile<List<BuildGroup>> ("./manifest.yaml");
 var BUILD_NAMES = Argument ("names", Argument ("name", Argument ("n", "")))

--- a/build.cake
+++ b/build.cake
@@ -16,6 +16,7 @@ var BUILD_NAMES = Argument ("names", Argument ("name", Argument ("n", "")))
 var BUILD_TARGETS = Argument ("targets", Argument ("build-targets", Argument ("build-targets", Argument ("build", ""))))
 	.Split (new [] { ",", ";" }, StringSplitOptions.RemoveEmptyEntries);
 
+var COPY_OUTPUT_TO_ROOT = Argument("copyoutputtoroot", "false").ToLower().Equals("true");
 
 var FORCE_BUILD = Argument ("force", Argument ("forcebuild", Argument ("force-build", "false"))).ToLower ().Equals ("true");
 
@@ -218,6 +219,13 @@ void BuildGroups (List<BuildGroup> buildGroups, List<string> names, List<string>
 	Information ("Found DLL's ({0})", dlls.Count ());
 	foreach (var d in dlls)
 		Information ("{0}", d);
+	
+	// Copy all subdir output directories to a root level artifacts dir
+	if (COPY_OUTPUT_TO_ROOT) {
+		EnsureDirectoryExists("./artifacts");
+		CopyFiles("./**/output/*", "./artifacts", true);
+	}
+
 }
 
 


### PR DESCRIPTION
Devops doesn't play well with globbing patterns to publish artifacts, so we'll do that bit in cake here first.