### PR TITLE
[Guava] Added ListenableFuture binding and made dependencies sane again

### DIFF
--- a/Android/Guava/Guava.sln
+++ b/Android/Guava/Guava.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Guava", "source\Guava\Guava
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Guava.FailureAccess", "source\Guava.FailureAccess\Guava.FailureAccess.csproj", "{F77FD2C9-181F-43C9-9533-20EE845F74BC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Guava.ListenableFuture", "source\Guava.ListenableFuture\Guava.ListenableFuture.csproj", "{6ADF0C2E-8513-40E6-921B-08AEFD7CBDD6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{F77FD2C9-181F-43C9-9533-20EE845F74BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F77FD2C9-181F-43C9-9533-20EE845F74BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F77FD2C9-181F-43C9-9533-20EE845F74BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ADF0C2E-8513-40E6-921B-08AEFD7CBDD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ADF0C2E-8513-40E6-921B-08AEFD7CBDD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ADF0C2E-8513-40E6-921B-08AEFD7CBDD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ADF0C2E-8513-40E6-921B-08AEFD7CBDD6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Android/Guava/build.cake
+++ b/Android/Guava/build.cake
@@ -1,10 +1,17 @@
+#addin nuget:?package=SharpZipLib
+
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var GUAVA_NUGET_VERSION = "27.1";
-var GUAVA_FAILUREACCESS_NUGET_VERSION = "1.0.1";
+var GUAVA_VERSION_BASE = "27.1";
+var GUAVA_VERSION = GUAVA_VERSION_BASE + "-android";
+var GUAVA_FAILUREACCESS_VERSION = "1.0.1";
+var GUAVA_LISTENABLEFUTURE_VERSION = "1.0";
 
-var GUAVA_VERSION = GUAVA_NUGET_VERSION + "-android";
-var GUAVA_FAILUREACCESS_VERSION = GUAVA_FAILUREACCESS_NUGET_VERSION;
+var GUAVA_NUGET_VERSION = "27.1.0.1";
+var GUAVA_FAILUREACCESS_NUGET_VERSION = GUAVA_FAILUREACCESS_VERSION;
+var GUAVA_LISTENABLEFUTURE_NUGET_VERSION = GUAVA_LISTENABLEFUTURE_VERSION;
+
+
 var JSR305_VERSION = "3.0.2";
 var CHECKER_COMPAT_QUAL_VERSION = "2.5.5";
 var ERROR_PRONE_ANNOTATIONS_VERSION = "2.3.3";
@@ -16,6 +23,10 @@ var GUAVA_DOCS_URL = string.Format ("http://search.maven.org/remotecontent?filep
 
 var GUAVA_FAILUREACCESS_JAR_URL = string.Format ("https://search.maven.org/remotecontent?filepath=com/google/guava/failureaccess/{0}/failureaccess-{0}.jar", GUAVA_FAILUREACCESS_VERSION);
 var GUAVA_FAILUREACCESS_DOCS_URL = string.Format("https://search.maven.org/remotecontent?filepath=com/google/guava/failureaccess/{0}/failureaccess-{0}-javadoc.jar", GUAVA_FAILUREACCESS_VERSION);
+
+var GUAVA_LISTENABLEFUTURE_JAR_URL = string.Format ("https://search.maven.org/remotecontent?filepath=com/google/guava/listenablefuture/{0}/listenablefuture-{0}.jar", GUAVA_LISTENABLEFUTURE_VERSION);
+var GUAVA_LISTENABLEFUTURE_DOCS_URL = string.Format("https://search.maven.org/remotecontent?filepath=com/google/guava/listenablefuture/{0}/listenablefuture-{0}-javadoc.jar", GUAVA_LISTENABLEFUTURE_VERSION);
+
 
 var JSR305_JAR_URL = string.Format("https://search.maven.org/remotecontent?filepath=com/google/code/findbugs/jsr305/{0}/jsr305-{0}.jar", JSR305_VERSION);
 var CHECKER_COMPAT_QUAL_JAR_URL = string.Format("https://search.maven.org/remotecontent?filepath=org/checkerframework/checker-compat-qual/{0}/checker-compat-qual-{0}.jar", CHECKER_COMPAT_QUAL_VERSION);
@@ -37,6 +48,9 @@ Task ("externals")
 	DownloadFile(GUAVA_FAILUREACCESS_JAR_URL, "./externals/guava-failureaccess.jar");
 	DownloadFile(GUAVA_FAILUREACCESS_DOCS_URL, "./externals/guava-failureaccess-javadocs.jar");
 
+	DownloadFile(GUAVA_LISTENABLEFUTURE_JAR_URL, "./externals/guava-listenablefuture.jar");
+	DownloadFile(GUAVA_LISTENABLEFUTURE_DOCS_URL, "./externals/guava-listenablefuture-javadocs.jar");
+
 	DownloadFile(JSR305_JAR_URL, "./externals/jsr305-annotations.jar");
 	DownloadFile(CHECKER_COMPAT_QUAL_JAR_URL, "./externals/checker-compat-qual-annotations.jar");
 	DownloadFile(ERROR_PRONE_ANNOTATIONS_JAR_URL, "./externals/error-prone-annotations.jar");
@@ -45,10 +59,42 @@ Task ("externals")
 
 	Unzip ("./externals/guava-javadocs.jar", "./externals/guava-javadocs/");
 	Unzip ("./externals/guava-failureaccess-javadocs.jar", "./externals/guava-failureaccess-javadocs/");
+	Unzip ("./externals/guava-listenablefuture-javadocs.jar", "./externals/guava-listenablefuture-javadocs/");
+
+	// We strip out ListenableFuture.class interface from the guava.jar file because the listenablefuture.jar has it already
+	// Google did something weird where they make guava depend on listenablefuture version 9999.0-something which is just
+	// a blank/empty artifact so that they avoid the conflict/duplicate interface in both places.
+	// They should have moved the code out of guava.jar and taken a normal dependency on listenablefuture.jar.
+
+	// guava.jar is ~2mb and listenablefuture.jar is like 3kb, it only has one single interface in it
+	// So in order to not make users depend on a 2mb file when they really only need the 3kb one, yet not have duplicate
+	// types if they have another dependency which DOES depend on the full guava.jar, and rather than replicate
+	// the weird high version number of the empty version of the one, we are going to fix the guava.jar to exclude
+	// this type and just always make it depend on listenablefuture which does have the actual implementation
+
+	// All we really need to do is remove the .class file from the .jar (which is a zip):
+	ICSharpCode.SharpZipLib.Zip.ZipFile zipFile = null;
+	try
+	{
+		zipFile = new ICSharpCode.SharpZipLib.Zip.ZipFile("./externals/guava.jar");
+		zipFile.BeginUpdate();
+		 var entry = zipFile.GetEntry("com/google/common/util/concurrent/ListenableFuture.class");
+		 if (entry != null) {
+			 Information("Deleting File from guava.jar: {0}", "ListenableFuture.class");
+			zipFile.Delete(entry);
+		}
+		zipFile.CommitUpdate();
+	}
+	finally
+	{
+		if (zipFile != null)
+			zipFile.Close();
+	}
 
 	// Update .csproj nuget versions
 	XmlPoke("./source/Guava/Guava.csproj", "/Project/PropertyGroup/PackageVersion", GUAVA_NUGET_VERSION);
 	XmlPoke("./source/Guava.FailureAccess/Guava.FailureAccess.csproj", "/Project/PropertyGroup/PackageVersion", GUAVA_FAILUREACCESS_NUGET_VERSION);
+	XmlPoke("./source/Guava.ListenableFuture/Guava.ListenableFuture.csproj", "/Project/PropertyGroup/PackageVersion", GUAVA_LISTENABLEFUTURE_NUGET_VERSION);
 });
 
 

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
@@ -3,22 +3,22 @@
   <PropertyGroup>
     <TargetFrameworks>MonoAndroid50</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
-    <AssemblyName>Xamarin.Google.Guava</AssemblyName>
+    <AssemblyName>Xamarin.Google.Guava.ListenableFuture</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <RootNamespace>Guava</RootNamespace>
+    <RootNamespace>Guava.ListenableFuture</RootNamespace>
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
-    <Java7DocPaths>..\..\externals\guava-javadocs\</Java7DocPaths>
+    <Java7DocPaths>..\..\externals\guava-listenablefuture-javadocs\</Java7DocPaths>
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>Xamarin.Google.Guava</PackageId>
-    <Title>Google Guava reference library for Xamarin.Android</Title>
-    <Summary>Xamarin.Android bindings for Google Guava</Summary>
+    <PackageId>Xamarin.Google.Guava.ListenableFuture</PackageId>
+    <Title>Google Guava ListenableFuture reference library for Xamarin.Android</Title>
+    <Summary>Xamarin.Android bindings for Google Guava ListenableFuture</Summary>
     <Description>
     NOTE: This package is meant to be used as a reference only for other binding projects that depend on Guava.
     This package does not expose any useful API's in the .dll itself.
@@ -31,7 +31,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865028</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865030</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>27.1.0.1</PackageVersion>
+    <PackageVersion>1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,43 +39,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\externals\guava.jar">
-      <Link>guava.jar</Link>
-    </None>
-    <None Include="..\..\externals\animal-sniffer-annotations.jar">
-      <Link>animal-sniffer-annotations.jar</Link>
-    </None>
-    <None Include="..\..\externals\checker-compat-qual-annotations.jar">
-      <Link>checker-compat-qual-annotations.jar</Link>
-    </None>
-    <None Include="..\..\externals\error-prone-annotations.jar">
-      <Link>error-prone-annotations.jar</Link>
-    </None>
-    <None Include="..\..\externals\j2objc-annotations.jar">
-      <Link>j2objc-annotations.jar</Link>
-    </None>
-    <None Include="..\..\externals\jsr305-annotations.jar">
-      <Link>jsr305-annotations.jar</Link>
+    <None Include="..\..\externals\guava-listenablefuture.jar">
+      <Link>guava-listenablefuture.jar</Link>
     </None>
     <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedReferenceJar Include="..\..\externals\guava.jar" />
-    <ReferenceJar Include="..\..\externals\animal-sniffer-annotations.jar" />
-    <ReferenceJar Include="..\..\externals\checker-compat-qual-annotations.jar" />
-    <ReferenceJar Include="..\..\externals\error-prone-annotations.jar" />
-    <ReferenceJar Include="..\..\externals\j2objc-annotations.jar" />
-    <ReferenceJar Include="..\..\externals\jsr305-annotations.jar" />
+    <EmbeddedJar Include="..\..\externals\guava-listenablefuture.jar" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.4.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Guava.FailureAccess\Guava.FailureAccess.csproj" />
-    <ProjectReference Include="..\Guava.ListenableFuture\Guava.ListenableFuture.csproj" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/Android/Guava/source/Guava.ListenableFuture/Transforms/Metadata.xml
+++ b/Android/Guava/source/Guava.ListenableFuture/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+  <remove-node path="/api/package" />
+</metadata>

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -102,6 +102,7 @@
   BuildScript: ./Android/Guava/build.cake
   TriggerPaths: [ Android/Guava ]
   MacBuildTargets: [ nuget ]
+  WindowsBuildTargets: [ nuget ]
 - Name: JacksonCore
   BuildScript: ./Android/Jackson.Core/build.cake
   TriggerPaths: [ Android/Jackson.Core ]


### PR DESCRIPTION
This adds a binding to ListenableFuture and fixes up some weird dependency implementations on Google's side...

A bit of history:
- Firebase Firestore for Android depends on `com.google.guava:guava`
- WorkManager depends on `com.google.guava:listenablefuture:1.0`

But...
- `com.google.guava:guava` contains the interface `com.google.common.util.concurrent.ListenableFuture`
- `com.google.guava:listenablefuture` _also_ contains this interface

To fix this duplicate type problem in the event of referencing both....
- `guava` depends on >= `listenablefuture` version >= `9999.0-empty-to-avoid-conflict-with-guava`
- `listenablefuture:9999.0-empty-to-avoid-conflict-with-guava` is an empty package, it does not contain the interface `com.google.common.util.concurrent.ListenableFuture`

So, instead of making `listenablefuture` a normal dependency of `guava` and moving the `ListenableFuture` implementation out of `guava` and *only* into `listenablefuture`, they did that weird version trick.

This matters because:
- `guava` is ~2.3mb
- `listenablefuture` is ~3kb (it is literally a .jar file with one interface with one method)
- We don't want users of `WorkManager` to incur 2.3mb of overhead if they aren't using anything else which needs the full `guava` and they only need 3kb.

We could:
a. Do a weird version thing with our nuget packages like Google does
b. Do some .targets trickery to mess with `ReferencedAssemblies`
c. Remove `listenablefuture` from `guava.jar` and make our `guava` binding depend on our `listenablefuture` binding and the `ListenableFuture` implementation just always lives there

This is choosing option *c*.