### PR TITLE
[Glide] use [assembly:LinkerSafe]

### DIFF
--- a/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Properties/AssemblyInfo.cs
+++ b/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Android.LinkerSafe]

--- a/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Properties/AssemblyInfo.cs
+++ b/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Android.LinkerSafe]

--- a/Android/Glide/source/Xamarin.Android.Glide/Properties/AssemblyInfo.cs
+++ b/Android/Glide/source/Xamarin.Android.Glide/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: Android.LinkerSafe]


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/glidex/pull/35
Context: https://www.nuget.org/packages/glidex/

I want to depend on the Xamarin.Android.Glide NuGet in glidex.forms. I have my own binding for glide (named glidex), but I'd rather just get rid of it.

Since #548 updates Glide to a new version, I think I can depend on Xamarin.Android.Glide when a NuGet update ships.

The *only* thing superior I found in my binding was `[assembly:LinkerSafe]`. This change adds it.