### PR TITLE
[Android/Guava] fix for missing [assembly:TargetFramework]

### DIFF
--- a/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.cs
+++ b/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.cs
@@ -1,0 +1,2 @@
+// A single @(Compile) item is required for MSBuild to put [assembly:TargetFramework] in the output assembly
+// See: https://github.com/microsoft/msbuild/blob/0cd0e92a7243088977d31b56626b56d6116de016/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3341-L3344

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.cs
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.cs
@@ -1,0 +1,2 @@
+// A single @(Compile) item is required for MSBuild to put [assembly:TargetFramework] in the output assembly
+// See: https://github.com/microsoft/msbuild/blob/0cd0e92a7243088977d31b56626b56d6116de016/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3341-L3344


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/3343
Context: https://github.com/xamarin/xamarin-android/issues/3343#issuecomment-511589968
Context: https://github.com/xamarin/xamarin-android/pull/2934

In Visual Studio 2019 16.1, we added some performance improvements in
Xamarin.Android.

In cases of .NET assemblies that:

* Do not have `[assembly: TargetFramework ("MonoAndroid")]`
* Have no reference to `Mono.Android.dll`

Unfortunately, these two Guava projects fit into this category! They
include `<EmbeddedJar/>` but otherwise have no markings at all that
would indicate they are Xamarin.Android assemblies.

Reading the source code for MSBuild, I found that including a single
`@(Compile)` item solves the issue:

https://github.com/microsoft/msbuild/blob/0cd0e92a7243088977d31b56626b56d6116de016/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3341-L3344

    <ItemGroup Condition="'@(Compile)' != '' and '$(TargetFrameworkMonikerAssemblyAttributeText)' != ''">
      <Compile Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>
    </ItemGroup>

As soon as I added an empty `*.cs` file to the projects,
`[assembly:TargetFramework]` appeared in the output assembly with the
necessary info.

This must be a weird corner case for MSBuild... I am not sure if there
is anything we can do on the Xamarin.Android side yet.