### PR TITLE
Updated SceneForm to 1.11.0

### DIFF
--- a/Android/SceneForm/build.cake
+++ b/Android/SceneForm/build.cake
@@ -4,7 +4,7 @@ var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var SF_VERSION = "1.11.0";
 
-var NUGET_VERSION = "1.11.0-preview1";
+var NUGET_VERSION = "1.11.0";
 
 var BASE_JAR_URL = $"https://dl.google.com/dl/android/maven2/com/google/ar/sceneform/sceneform-base/{SF_VERSION}/sceneform-base-{SF_VERSION}.aar";
 var ANIMATION_JAR_URL = $"https://dl.google.com:443/dl/android/maven2/com/google/ar/sceneform/animation/{SF_VERSION}/animation-{SF_VERSION}.aar";

--- a/Android/SceneForm/build.cake
+++ b/Android/SceneForm/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var SF_VERSION = "1.10.0";
+var SF_VERSION = "1.11.0";
 
-var NUGET_VERSION = "1.10.0-preview1";
+var NUGET_VERSION = "1.11.0-preview1";
 
 var BASE_JAR_URL = $"https://dl.google.com/dl/android/maven2/com/google/ar/sceneform/sceneform-base/{SF_VERSION}/sceneform-base-{SF_VERSION}.aar";
 var ANIMATION_JAR_URL = $"https://dl.google.com:443/dl/android/maven2/com/google/ar/sceneform/animation/{SF_VERSION}/animation-{SF_VERSION}.aar";

--- a/Android/SceneForm/cgmanifest.json
+++ b/Android/SceneForm/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "assets",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -16,7 +16,7 @@
         "Maven": {
           "ArtifactId": "animation",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -26,7 +26,7 @@
         "Maven": {
           "ArtifactId": "core",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -36,7 +36,7 @@
         "Maven": {
           "ArtifactId": "filament-android",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -46,7 +46,7 @@
         "Maven": {
           "ArtifactId": "rendering",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -56,7 +56,7 @@
         "Maven": {
           "ArtifactId": "sceneform-base",
           "GroupId": "com.google.ar.sceneform",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     },
@@ -66,7 +66,7 @@
         "Maven": {
           "ArtifactId": "sceneform-ux",
           "GroupId": "com.google.ar.sceneform.ux",
-          "Version": "1.10.0"
+          "Version": "1.11.0"
         }
       }
     }

--- a/Android/SceneForm/samples/hellosceneform/hellosceneform.csproj
+++ b/Android/SceneForm/samples/hellosceneform/hellosceneform.csproj
@@ -100,7 +100,7 @@
     <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.Fragment" Version="28.0.0.1" />
-    <PackageReference Include="Xamarin.Google.ARCore" Version="1.10.0" />
+    <PackageReference Include="Xamarin.Google.ARCore" Version="1.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\source\Animation\Animation.csproj">

--- a/Android/SceneForm/source/Animation/Animation.csproj
+++ b/Android/SceneForm/source/Animation/Animation.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Animation/Animation.csproj
+++ b/Android/SceneForm/source/Animation/Animation.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Assets/Assets.csproj
+++ b/Android/SceneForm/source/Assets/Assets.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Assets/Assets.csproj
+++ b/Android/SceneForm/source/Assets/Assets.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Base/Base.csproj
+++ b/Android/SceneForm/source/Base/Base.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Base/Base.csproj
+++ b/Android/SceneForm/source/Base/Base.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Core/Core.csproj
+++ b/Android/SceneForm/source/Core/Core.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Core/Core.csproj
+++ b/Android/SceneForm/source/Core/Core.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Filament/Filament.csproj
+++ b/Android/SceneForm/source/Filament/Filament.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Filament/Filament.csproj
+++ b/Android/SceneForm/source/Filament/Filament.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Rendering/Rendering.csproj
+++ b/Android/SceneForm/source/Rendering/Rendering.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/Rendering/Rendering.csproj
+++ b/Android/SceneForm/source/Rendering/Rendering.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Google.ARCore" Version="1.10.0" />
+    <PackageReference Include="Xamarin.Google.ARCore" Version="1.11.0" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/Android/SceneForm/source/UX/UX.csproj
+++ b/Android/SceneForm/source/UX/UX.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.10.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/SceneForm/source/UX/UX.csproj
+++ b/Android/SceneForm/source/UX/UX.csproj
@@ -25,7 +25,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2083771</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2083684</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.11.0-preview1</PackageVersion>
+    <PackageVersion>1.11.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Based on the changes from #631, this change updates the SceneForm bindings to version 1.11.0 consuming ARCore 1.11.0.

This should be the last to resolve #608.