### PR TITLE
Binderator: Allow more explicit external download naming

### DIFF
--- a/Util/Xamarin.AndroidBinderator/README.md
+++ b/Util/Xamarin.AndroidBinderator/README.md
@@ -21,6 +21,7 @@ Here is what a basic config file might look like:
     {
         "mavenRepositoryType" : "Google",
         "slnFile" : "generated/AndroidSupport.sln",
+        "downloadExternalsWithFullName" : true,
         "additionalProjects" : [
             "source/buildtasks/support-annotations/Support-Annotations-BuildTasks.csproj"
         ],

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -8,8 +8,8 @@ namespace AndroidBinderator
 		[JsonProperty("basePath")]
 		public string BasePath { get; set; } = null;
 
-        [JsonProperty("downloadExternalsWithFullName")]
-        public bool DownloadExternalsWithFullName { get; set; } = false;
+		[JsonProperty("downloadExternalsWithFullName")]
+		public bool DownloadExternalsWithFullName { get; set; } = false;
 
 		[JsonProperty("mavenRepositoryType")]
 		public MavenRepoType MavenRepositoryType { get; set; } = MavenRepoType.Google;

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -8,6 +8,9 @@ namespace AndroidBinderator
 		[JsonProperty("basePath")]
 		public string BasePath { get; set; } = null;
 
+        [JsonProperty("downloadExternalsWithFullName")]
+        public bool DownloadExternalsWithFullName { get; set; } = false;
+
 		[JsonProperty("mavenRepositoryType")]
 		public MavenRepoType MavenRepositoryType { get; set; } = MavenRepoType.Google;
 

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -139,10 +139,10 @@ namespace AndroidBinderator
 					config.ExternalsDir,
 					mavenArtifact.GroupId);
 				var artifactFile = Path.Combine(artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}.{mavenProject.Packaging}"
-                    : $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
+					: $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
 				var md5File = artifactFile + ".md5";
 				var sourcesFile = Path.Combine(artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}-sources.jar"
-                    : $"{mavenArtifact.ArtifactId}-sources.jar");
+					: $"{mavenArtifact.ArtifactId}-sources.jar");
 				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId);
 
 				if (!Directory.Exists(artifactDir))

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -138,9 +138,11 @@ namespace AndroidBinderator
 					config.BasePath,
 					config.ExternalsDir,
 					mavenArtifact.GroupId);
-				var artifactFile = Path.Combine(artifactDir, $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
+				var artifactFile = Path.Combine(artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}.{mavenProject.Packaging}"
+                    : $"{mavenArtifact.ArtifactId}.{mavenProject.Packaging}");
 				var md5File = artifactFile + ".md5";
-				var sourcesFile = Path.Combine(artifactDir, $"{mavenArtifact.ArtifactId}-sources.jar");
+				var sourcesFile = Path.Combine(artifactDir, config.DownloadExternalsWithFullName ? $"{mavenArtifact.GroupId}.{mavenArtifact.ArtifactId}-sources.jar"
+                    : $"{mavenArtifact.ArtifactId}-sources.jar");
 				var artifactExtractDir = Path.Combine(artifactDir, mavenArtifact.ArtifactId);
 
 				if (!Directory.Exists(artifactDir))


### PR DESCRIPTION
This allows a config flag to be set `downloadExternalsWithFullName` to be set in order to have artifacts downloaded as `{groupId}.{artifactId}.jar` instead of just `{artifactId}.jar`.  We have cases in android support (and maybe androidx? ) where artifacts share a name (eg: `common`) and then you end up with binding dll's with .jar's with the same name in them causing errors in the xamarin.android build due to duplicate .jar names.