### PR TITLE
More improvements to Kotlin BindingSupport

### DIFF
--- a/Util/Xamarin.Kotlin.BindingSupport/build.cake
+++ b/Util/Xamarin.Kotlin.BindingSupport/build.cake
@@ -1,7 +1,7 @@
 
 var TARGET = Argument("t", Argument("target", "Default"));
 
-var PACKAGE_VERSION = "0.4.0-preview";
+var PACKAGE_VERSION = "0.5.0-preview";
 
 Task("externals")
 	.Does(() =>

--- a/Util/Xamarin.Kotlin.BindingSupport/build.cake
+++ b/Util/Xamarin.Kotlin.BindingSupport/build.cake
@@ -1,7 +1,7 @@
 
 var TARGET = Argument("t", Argument("target", "Default"));
 
-var PACKAGE_VERSION = "0.5.0-preview";
+var PACKAGE_VERSION = "0.5.2-preview";
 
 Task("externals")
 	.Does(() =>

--- a/Util/Xamarin.Kotlin.BindingSupport/native/src/main/kotlin/xamarin/binding/kotlin/bindingsupport/ProcessXmlCommand.kt
+++ b/Util/Xamarin.Kotlin.BindingSupport/native/src/main/kotlin/xamarin/binding/kotlin/bindingsupport/ProcessXmlCommand.kt
@@ -20,8 +20,9 @@ class ProcessXmlCommand : CliktCommand(name = "KotlinBindingSupport") {
     val outputFile: File? by option("-o", "--output", help = "path to the output transform file")
         .file(fileOkay = true, folderOkay = false)
 
-    val ignoreFile: File? by option("-i", "--ignore", help = "path to the ignore file")
-        .file(fileOkay = true, folderOkay = false)
+    val ignoreFiles: List<File> by option("-i", "--ignore", help = "paths to the ignore files")
+        .file(exists = true)
+        .multiple()
 
     val companions: Processor.CompanionProcessing by option("--companions", help = "indicate how to handle companions")
         .choice(
@@ -35,7 +36,7 @@ class ProcessXmlCommand : CliktCommand(name = "KotlinBindingSupport") {
         .flag(default = false)
 
     override fun run() {
-        val proc = Processor(xmlFile, jarFiles, outputFile, ignoreFile)
+        val proc = Processor(xmlFile, jarFiles, outputFile, ignoreFiles)
         proc.verbose = verbose
         proc.companions = companions
         proc.process()

--- a/Util/Xamarin.Kotlin.BindingSupport/nuget/Xamarin.Kotlin.BindingSupport.nuspec
+++ b/Util/Xamarin.Kotlin.BindingSupport/nuget/Xamarin.Kotlin.BindingSupport.nuspec
@@ -15,6 +15,7 @@
   </metadata>
   <files>
     <file src="..\native\build\libs\binding-support-1.0.jar" target="build\monoandroid1.0\binding-support-1.0.jar" />
+    <file src="..\source\Xamarin.Kotlin.BindingSupport.props" target="build\monoandroid1.0\Xamarin.Kotlin.BindingSupport.props" />
     <file src="..\source\Xamarin.Kotlin.BindingSupport.targets" target="build\monoandroid1.0\Xamarin.Kotlin.BindingSupport.targets" />
   </files>
 </package>

--- a/Util/Xamarin.Kotlin.BindingSupport/samples/BubblePickerBinding/BubblePickerBinding.csproj
+++ b/Util/Xamarin.Kotlin.BindingSupport/samples/BubblePickerBinding/BubblePickerBinding.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
+  <Import Project="..\..\source\Xamarin.Kotlin.BindingSupport.props" />
+
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>

--- a/Util/Xamarin.Kotlin.BindingSupport/samples/KotlinBinding12/KotlinBinding12.csproj
+++ b/Util/Xamarin.Kotlin.BindingSupport/samples/KotlinBinding12/KotlinBinding12.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
+  <Import Project="..\..\source\Xamarin.Kotlin.BindingSupport.props" />
+
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>

--- a/Util/Xamarin.Kotlin.BindingSupport/samples/KotlinBinding13/KotlinBinding13.csproj
+++ b/Util/Xamarin.Kotlin.BindingSupport/samples/KotlinBinding13/KotlinBinding13.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
+  <Import Project="..\..\source\Xamarin.Kotlin.BindingSupport.props" />
+
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
@@ -38,6 +40,7 @@
     <None Remove="Transforms\*.xml" />
     <TransformFile Include="Transforms\*.xml" />
     <InputJar Include="..\..\externals\kotlin-stdlib-1.3.jar" Link="Jars\kotlin-stdlib-1.3.jar" />
+    <KotlinBindingSupportIgnore Include="ignore.txt" />
   </ItemGroup>
 
   <Import Project="..\..\source\Xamarin.Kotlin.BindingSupport.targets" />

--- a/Util/Xamarin.Kotlin.BindingSupport/source/Xamarin.Kotlin.BindingSupport.props
+++ b/Util/Xamarin.Kotlin.BindingSupport/source/Xamarin.Kotlin.BindingSupport.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <AvailableItemName Include="KotlinBindingSupportIgnore" />  
+  </ItemGroup>
+
+</Project>

--- a/Util/Xamarin.Kotlin.BindingSupport/source/Xamarin.Kotlin.BindingSupport.targets
+++ b/Util/Xamarin.Kotlin.BindingSupport/source/Xamarin.Kotlin.BindingSupport.targets
@@ -16,16 +16,23 @@
     <PropertyGroup>
       <KotlinBindingSupportJar Condition="'$(KotlinBindingSupportJar)' == ''">$(MSBuildThisFileDirectory)binding-support-1.0.jar</KotlinBindingSupportJar>
       <KotlinBindingSupportExtraArgs Condition="'$(KotlinBindingSupportExtraArgs)' == ''"></KotlinBindingSupportExtraArgs>
-      <KotlinBindingSupportIgnorePath Condition="'$(KotlinBindingSupportIgnorePath)' == ''"></KotlinBindingSupportIgnorePath>
       <KotlinBindingSupportOutputPath Condition="'$(KotlinBindingSupportOutputPath)' == ''">$(IntermediateOutputPath)\KotlinBindingSupport.generated.xml</KotlinBindingSupportOutputPath>
       <KotlinBindingSupportAndroidJarPath Condition="'$(KotlinBindingSupportAndroidJarPath)' == ''">$(AndroidSdkDirectory)\platforms\android-$(_AndroidApiLevelName)\android.jar</KotlinBindingSupportAndroidJarPath>
     </PropertyGroup>
+
+    <!-- OBSOLETE: use @(KotlinBindingSupportIgnore) instead -->
+    <PropertyGroup>
+      <KotlinBindingSupportIgnorePath Condition="'$(KotlinBindingSupportIgnorePath)' == ''"></KotlinBindingSupportIgnorePath>
+    </PropertyGroup>
+    <ItemGroup>
+      <KotlinBindingSupportIgnore Condition="'$(KotlinBindingSupportIgnorePath)' != ''" Include="$(KotlinBindingSupportIgnorePath)" />
+    </ItemGroup>
 
     <!-- private properties -->
     <PropertyGroup>
       <_KotlinBindingJavaPath Condition="'$(_KotlinBindingJavaPath)' == '' and '$(OS)' == 'Unix'">$(JavaSdkDirectory)\bin\java</_KotlinBindingJavaPath>
       <_KotlinBindingJavaPath Condition="'$(_KotlinBindingJavaPath)' == '' and '$(OS)' != 'Unix'">$(JavaSdkDirectory)\bin\java.exe</_KotlinBindingJavaPath>
-      <_KotlinBindingSupportIgnore Condition="'$(KotlinBindingSupportIgnorePath)' != ''">--ignore &quot;$(KotlinBindingSupportIgnorePath)&quot;</_KotlinBindingSupportIgnore>
+      <_KotlinBindingSupportIgnore Condition="'@(KotlinBindingSupportIgnore)' != ''">--ignore &quot;@(KotlinBindingSupportIgnore, '&quot; --ignore &quot;')&quot;</_KotlinBindingSupportIgnore>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
More improvements to Kotlin BindingSupport:
* more wildcard support: `startsWith*`, `*endsWith`, `*contains*`
* ignore multiple files with @(KotlinBindingSupportIgnore) build action
* fix for the Cloneable interface errors
* fix issue with non-static nested classes