### PR TITLE
Updated ARCore to 1.12.0

### DIFF
--- a/Android/ARCore/README.md
+++ b/Android/ARCore/README.md
@@ -6,17 +6,46 @@ With ARCore, shape brand new experiences that seamlessly blend the digital and p
 
 ## Building
 
-Use the `build.cake` script to build.  You can execute it via one of the bootstrappers (`build.sh` on mac or `build.ps1` on windows):
+### Prerequisites
 
-Mac:
-```
-sh ../../build.sh --target libs
+Before building the libraries and samples in this repository, you will need to install [.NET Core](https://dotnet.microsoft.com/download) and the [Cake .NET Core Tool](http://cakebuild.net):
+
+```sh
+dotnet tool install -g cake.tool
 ```
 
-Windows:
+### Compiling
+
+To build the `ARCore` component, you can either start the build from the root:
+
+```sh
+dotnet cake --name=ARCore --target=libs
 ```
-powershell ..\..\build.ps1 -Target libs
+
+Or, you can navigate to the folder and run it from there:
+
+```sh
+cd Android/ARCore
+dotnet cake --target=libs
 ```
+
+The following targets can be specified using the `--target=<target-name>`:
+
+- `externals` downloads and builds the external dependencies
+- `libs` builds the class library bindings (depends on `externals`)
+- `nuget` builds the nuget packages (depends on `libs`)
+- `samples` builds all of the samples (depends on `nuget`)
+- `clean` cleans up everything
+
+### Working in Visual Studio
+
+Before the `.sln` files will compile in the IDEs, the external dependencies need to be downloaded. This can be done by running the `externals` target:
+
+```sh
+dotnet cake --target=externals
+```
+
+After the externals are downloaded and built, the `.sln` files should compile in your IDE.
 
 ## Running ARCore
 

--- a/Android/ARCore/build.cake
+++ b/Android/ARCore/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var NUGET_VERSION = "1.11.0";
+var NUGET_VERSION = "1.12.0";
 
-var AAR_VERSION = "1.11.0";
+var AAR_VERSION = "1.12.0";
 var AAR_URL = string.Format("https://dl.google.com/dl/android/maven2/com/google/ar/core/{0}/core-{0}.aar", AAR_VERSION);
 var OBJ_VERSION = "0.3.0";
 var OBJ_URL = string.Format("https://oss.sonatype.org/content/repositories/releases/de/javagl/obj/{0}/obj-{0}.jar", OBJ_VERSION);
@@ -13,7 +13,7 @@ var buildSpec = new BuildSpec () {
 	Libs = new [] {
 		new DefaultSolutionBuilder {
 			SolutionPath = "./ARCore.sln",
-			OutputFiles = new [] { 
+			OutputFiles = new [] {
 				new OutputFileCopy {
 					FromFile = "./source/bin/Release/Xamarin.Google.ARCore.dll",
 				}
@@ -27,7 +27,7 @@ var buildSpec = new BuildSpec () {
 };
 
 Task ("externals")
-	.Does (() => 
+	.Does (() =>
 {
 	var AAR_FILE = "./externals/arcore.aar";
 	var OBJ_JAR_FILE = "./externals/obj.jar";
@@ -43,8 +43,8 @@ Task ("externals")
 });
 
 
-Task ("clean").IsDependentOn ("clean-base").Does (() => 
-{	
+Task ("clean").IsDependentOn ("clean-base").Does (() =>
+{
 	if (DirectoryExists ("./externals"))
 		DeleteDirectory ("./externals", true);
 });

--- a/Android/ARCore/nuget/Xamarin.Google.ARCore.nuspec
+++ b/Android/ARCore/nuget/Xamarin.Google.ARCore.nuspec
@@ -6,6 +6,7 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
+    <license type="file">LICENSE.md</license>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>Xamarin.Android Bindings for Google ARCore</summary>
     <description>
@@ -13,10 +14,14 @@
     </description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=864978</projectUrl>
-    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865040</licenseUrl>
+    <dependencies>
+      <group targetFramework="MonoAndroid7.0">
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="output/Xamarin.Google.ARCore.dll" target="lib/MonoAndroid70" />
     <file src="External-Dependency-Info.txt" target="THIRD-PARTY-NOTICES.txt" />
+    <file src="LICENSE.md" target="LICENSE.md" />
   </files>
 </package>

--- a/Android/ARCore/nuget/Xamarin.Google.ARCore.nuspec
+++ b/Android/ARCore/nuget/Xamarin.Google.ARCore.nuspec
@@ -20,7 +20,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Google.ARCore.dll" target="lib/MonoAndroid70" />
+    <file src="source/bin/Release/Xamarin.Google.ARCore.dll" target="lib/MonoAndroid70" />
     <file src="External-Dependency-Info.txt" target="THIRD-PARTY-NOTICES.txt" />
     <file src="LICENSE.md" target="LICENSE.md" />
   </files>

--- a/Android/ARCore/samples/HelloAR.sln
+++ b/Android/ARCore/samples/HelloAR.sln
@@ -32,6 +32,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.11.0
+		version = 1.12.0
 	EndGlobalSection
 EndGlobal

--- a/Android/ARCore/samples/HelloAR/HelloAR.csproj
+++ b/Android/ARCore/samples/HelloAR/HelloAR.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>1.11.0</ReleaseVersion>
+    <ReleaseVersion>1.12.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/samples/JavaGL/JavaGL.csproj
+++ b/Android/ARCore/samples/JavaGL/JavaGL.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>1.11.0</ReleaseVersion>
+    <ReleaseVersion>1.12.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/source/Google.ARCore.csproj
+++ b/Android/ARCore/source/Google.ARCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
-    <ReleaseVersion>1.11.0</ReleaseVersion>
+    <ReleaseVersion>1.12.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
- Updates ARCore bindings to version 1.12.0.
- Fixed ARCore NuGet warnings: NU5125, NU5128
  - Fixed [NU5125](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5125) by including the license file in the nupkg.
  - Fixed [NU5128](https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) by adding a dependency group for MonoAndroid7.0 to the nuspec.
- "Fixed" the cake build for ARCore
  - I made the cake build work similar to the SceneForm project, which appears to be a more modern formula and happens to also work on Windows (the existing formula did not). This makes the instructions the same on both macOS and Windows.
- Updated the ARCore README.md
  - This change updates the README with updated instructions on how to build the ARCore component and samples.

I have run the HelloAR sample app and verified that it works correctly.

I realize that ARCore 1.13.0 is out and will follow-up with that change as well, but I think it's valuable to have packages for 1.11.0 as well.

Since the SceneForm projects depend on the ARCore NuGet package, i'll have to follow up with updates to the SceneForm bindings separately once the ARCore 1.12.0 NuGet package is available.