### PR TITLE
Add some required checks

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -252,9 +252,6 @@ jobs:
             --verbosity="${{ parameters.verbosity }}"
         displayName: 'Generate API diff'
       # after the build is complete
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Run component detection'
-        condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       - task: PublishBuildArtifacts@1
         displayName: 'Publish artifacts'
         inputs:
@@ -266,6 +263,15 @@ jobs:
         inputs:
           PathToPublish: output
           ArtifactName: output-$(System.JobName)
+      # run any required checks
+      - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+        - task: ComponentGovernanceComponentDetection@0
+          displayName: 'Run component detection'
+          condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+          inputs:
+            scanType: 'Register'
+            verbosity: 'Verbose'
+            alertWarningLevel: 'High'
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - job: checks

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -36,7 +36,7 @@ parameters:
 jobs:
   - job: checks
     displayName: 'Run required code checks'
-    condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+    #condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
     pool:
       name: ${{ parameters.windowsImage }}
     steps:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -42,7 +42,7 @@ jobs:
       - task: CredScan@2
         inputs:
           toolMajorVersion: 'V2'
-      - task: SdtReport@1@1
+      - task: SdtReport@1
         displayName: 'Create Security Analysis Report'
         inputs:
           CredScan: true

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -39,8 +39,9 @@ jobs:
     pool:
       name: ${{ parameters.windowsImage }}
     steps:
-      - pwsh: 'echo hello'
-        displayName: '$(Build.Repository.Name)_$(Build.SourceBranchName)'
+      - pwsh: |
+          $CODEBASE_NAME = "$(Build.Repository.Id)" + "_" + "$(Build.Repository.Name)" + "_" + "$(Build.SourceBranchName)"
+          Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
 #       - task: CredScan@2
 #         displayName: 'Analyze source for credentials'
 #         inputs:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -46,13 +46,25 @@ jobs:
       - task: SdtReport@1
         displayName: 'Create security analysis report'
         inputs:
-          CredScan: true
+          AllTools: true
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish security analysis logs'
+      - task: TSAUpload@1
+        inputs:
+          tsaVersion: 'TsaV2'
+          codebase: 'NewOrUpdate'
+          tsaEnvironment: 'PROD'
+          codeBaseName: 'XamarinComponents_master'
+          notificationAlias: 'xamacomd@microsoft.com'
+          notifyAlwaysV2: false
+          instanceUrlForTsaV2: 'DEVDIV'
+          projectNameDEVDIV: 'DevDiv'
+          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+          iterationPath: 'DevDiv\OneVS'
       - task: PostAnalysis@1
         displayName: 'Analyze security analysis report'
         inputs:
-          CredScan: true
+          AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -270,7 +270,7 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - job: checks
       displayName: 'Run required code checks'
-      #condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+      # condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
       pool:
         name: ${{ parameters.windowsImage }}
       steps:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -40,37 +40,38 @@ jobs:
       name: ${{ parameters.windowsImage }}
     steps:
       - pwsh: |
-          $repo = "$(Build.Repository.Id)".Replace("/", "_")
-          $branch = "$(Build.SourceBranchName)"
+          $repo = "$(Build.Repository.Id)"
+          $repo = $repo.Substring($repo.IndexOf("/") + 1)
+          $branch = "${{ parameters.masterBranchName }}"
           $CODEBASE_NAME = $repo + "_" + $branch
           echo "Using codebase: $CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-      - task: CredScan@2
-        displayName: 'Analyze source for credentials'
-        inputs:
-          toolMajorVersion: 'V2'
-      - task: SdtReport@1
-        displayName: 'Create security analysis report'
-        inputs:
-          AllTools: true
-      - task: PublishSecurityAnalysisLogs@3
-        displayName: 'Publish security analysis logs'
-      - task: TSAUpload@1
-        inputs:
-          tsaVersion: 'TsaV2'
-          codebase: 'NewOrUpdate'
-          tsaEnvironment: 'PROD'
-          codeBaseName: $(CODEBASE_NAME)
-          notificationAlias: 'xamacomd@microsoft.com'
-          notifyAlwaysV2: false
-          instanceUrlForTsaV2: 'DEVDIV'
-          projectNameDEVDIV: 'DevDiv'
-          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-          iterationPath: 'DevDiv\OneVS'
-      - task: PostAnalysis@1
-        displayName: 'Analyze security analysis report'
-        inputs:
-          AllTools: true
+      # - task: CredScan@2
+      #   displayName: 'Analyze source for credentials'
+      #   inputs:
+      #     toolMajorVersion: 'V2'
+      # - task: SdtReport@1
+      #   displayName: 'Create security analysis report'
+      #   inputs:
+      #     AllTools: true
+      # - task: PublishSecurityAnalysisLogs@3
+      #   displayName: 'Publish security analysis logs'
+      # - task: TSAUpload@1
+      #   inputs:
+      #     tsaVersion: 'TsaV2'
+      #     codebase: 'NewOrUpdate'
+      #     tsaEnvironment: 'PROD'
+      #     codeBaseName: $(CODEBASE_NAME)
+      #     notificationAlias: 'xamacomd@microsoft.com'
+      #     notifyAlwaysV2: false
+      #     instanceUrlForTsaV2: 'DEVDIV'
+      #     projectNameDEVDIV: 'DevDiv'
+      #     areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+      #     iterationPath: 'DevDiv\OneVS'
+      # - task: PostAnalysis@1
+      #   displayName: 'Analyze security analysis report'
+      #   inputs:
+      #     AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -34,6 +34,14 @@ parameters:
   targetsFilter: ''                                         # [manifest] the targets of the items to build
 
 jobs:
+  - job: checks
+    displayName: 'Run required code checks'
+    pool:
+      name: ${{ parameters.windowsImage }}
+    steps:
+      - task: CredScan@2
+        inputs:
+          toolMajorVersion: 'V2'
   - job: ${{ parameters.name }}
     strategy:
       matrix:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -303,7 +303,3 @@ jobs:
             projectNameDEVDIV: 'DevDiv'
             areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
             iterationPath: 'DevDiv\OneVS'
-        - task: PostAnalysis@1
-          displayName: 'Analyze security analysis report'
-          inputs:
-            AllTools: true

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -40,7 +40,7 @@ jobs:
       name: ${{ parameters.windowsImage }}
     steps:
       - task: CredScan@2
-        displayName: 'Analyse source for credentials'
+        displayName: 'Analyze source for credentials'
         inputs:
           toolMajorVersion: 'V2'
       - task: SdtReport@1
@@ -49,6 +49,10 @@ jobs:
           CredScan: true
       - task: PublishSecurityAnalysisLogs@3
         displayName: 'Publish security analysis logs'
+      - task: PostAnalysis@1
+        displayName: 'Analyze security analysis report'
+        inputs:
+          CredScan: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -285,6 +285,10 @@ jobs:
           displayName: 'Analyze source for credentials'
           inputs:
             toolMajorVersion: 'V2'
+        - task: PoliCheck@1
+          inputs:
+            inputType: 'Basic'
+            targetType: 'F'
         - task: SdtReport@1
           displayName: 'Create security analysis report'
           inputs:
@@ -297,7 +301,7 @@ jobs:
             FxCop: false
             ModernCop: false
             MSRD: false
-            PoliCheck: false
+            PoliCheck: true
             RoslynAnalyzers: false
             SDLNativeRules: false
             Semmle: false
@@ -323,7 +327,7 @@ jobs:
             uploadFortifySCA: false
             uploadFxCop: false
             uploadModernCop: false
-            uploadPoliCheck: false
+            uploadPoliCheck: true
             uploadPREfast: false
             uploadRoslyn: false
             uploadTSLint: false

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -42,6 +42,11 @@ jobs:
       - task: CredScan@2
         inputs:
           toolMajorVersion: 'V2'
+      - task: SdtReport@1@1
+        displayName: 'Create Security Analysis Report'
+        inputs:
+          CredScan: true
+
   - job: ${{ parameters.name }}
     strategy:
       matrix:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -267,7 +267,7 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0
           displayName: 'Run component detection'
-          condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+          condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
           inputs:
             scanType: 'Register'
             verbosity: 'Verbose'

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -36,7 +36,7 @@ parameters:
 jobs:
   - job: checks
     displayName: 'Run required code checks'
-    condition: eq("refs/head/${{ parameters.masterBranchName}}", variables['Build.SourceBranch'])
+    condition: eq('refs/head/${{ parameters.masterBranchName}}', variables['Build.SourceBranch'])
     pool:
       name: ${{ parameters.windowsImage }}
     steps:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -34,46 +34,6 @@ parameters:
   targetsFilter: ''                                         # [manifest] the targets of the items to build
 
 jobs:
-  - job: checks
-    displayName: 'Run required code checks'
-    #condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
-    pool:
-      name: ${{ parameters.windowsImage }}
-    steps:
-      - pwsh: |
-          $repo = "$(Build.Repository.Id)"
-          $repo = $repo.Substring($repo.IndexOf("/") + 1)
-          $branch = "${{ parameters.masterBranchName }}"
-          $CODEBASE_NAME = $repo + "_" + $branch
-          echo "Using codebase: $CODEBASE_NAME"
-          Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-      - task: CredScan@2
-        displayName: 'Analyze source for credentials'
-        inputs:
-          toolMajorVersion: 'V2'
-      - task: SdtReport@1
-        displayName: 'Create security analysis report'
-        inputs:
-          AllTools: true
-      - task: PublishSecurityAnalysisLogs@3
-        displayName: 'Publish security analysis logs'
-      - task: TSAUpload@1
-        inputs:
-          tsaVersion: 'TsaV2'
-          codebase: 'NewOrUpdate'
-          tsaEnvironment: 'PROD'
-          codeBaseName: $(CODEBASE_NAME)
-          notificationAlias: 'xamacomd@microsoft.com'
-          notifyAlwaysV2: false
-          instanceUrlForTsaV2: 'DEVDIV'
-          projectNameDEVDIV: 'DevDiv'
-          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-          iterationPath: 'DevDiv\OneVS'
-      - task: PostAnalysis@1
-        displayName: 'Analyze security analysis report'
-        inputs:
-          AllTools: true
-
   - job: ${{ parameters.name }}
     strategy:
       matrix:
@@ -306,3 +266,44 @@ jobs:
         inputs:
           PathToPublish: output
           ArtifactName: output-$(System.JobName)
+
+  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+    - job: checks
+      displayName: 'Run required code checks'
+      #condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+      pool:
+        name: ${{ parameters.windowsImage }}
+      steps:
+        - pwsh: |
+            $repo = "$(Build.Repository.Id)"
+            $repo = $repo.Substring($repo.IndexOf("/") + 1)
+            $branch = "${{ parameters.masterBranchName }}"
+            $CODEBASE_NAME = $repo + "_" + $branch
+            echo "Using codebase: $CODEBASE_NAME"
+            Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
+        - task: CredScan@2
+          displayName: 'Analyze source for credentials'
+          inputs:
+            toolMajorVersion: 'V2'
+        - task: SdtReport@1
+          displayName: 'Create security analysis report'
+          inputs:
+            AllTools: true
+        - task: PublishSecurityAnalysisLogs@3
+          displayName: 'Publish security analysis logs'
+        - task: TSAUpload@1
+          inputs:
+            tsaVersion: 'TsaV2'
+            codebase: 'NewOrUpdate'
+            tsaEnvironment: 'PROD'
+            codeBaseName: $(CODEBASE_NAME)
+            notificationAlias: 'xamacomd@microsoft.com'
+            notifyAlwaysV2: false
+            instanceUrlForTsaV2: 'DEVDIV'
+            projectNameDEVDIV: 'DevDiv'
+            areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+            iterationPath: 'DevDiv\OneVS'
+        - task: PostAnalysis@1
+          displayName: 'Analyze security analysis report'
+          inputs:
+            AllTools: true

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -267,7 +267,7 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0
           displayName: 'Run component detection'
-#           condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+          condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
           inputs:
             scanType: 'Register'
             verbosity: 'Verbose'

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -288,7 +288,21 @@ jobs:
         - task: SdtReport@1
           displayName: 'Create security analysis report'
           inputs:
-            AllTools: true
+            AllTools: false
+            APIScan: false
+            BinSkim: false
+            CodesignValidation: false
+            CredScan: true
+            FortifySCA: false
+            FxCop: false
+            ModernCop: false
+            MSRD: false
+            PoliCheck: false
+            RoslynAnalyzers: false
+            SDLNativeRules: false
+            Semmle: false
+            TSLint: false
+            ToolLogsNotFoundAction: 'Standard'
         - task: PublishSecurityAnalysisLogs@3
           displayName: 'Publish security analysis logs'
         - task: TSAUpload@1
@@ -296,10 +310,21 @@ jobs:
             tsaVersion: 'TsaV2'
             codebase: 'NewOrUpdate'
             tsaEnvironment: 'PROD'
-            codeBaseName: $(CODEBASE_NAME)
+            codeBaseName: '$(CODEBASE_NAME)'
             notificationAlias: 'xamacomd@microsoft.com'
             notifyAlwaysV2: false
             instanceUrlForTsaV2: 'DEVDIV'
             projectNameDEVDIV: 'DevDiv'
             areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
             iterationPath: 'DevDiv\OneVS'
+            uploadAPIScan: false
+            uploadBinSkim: false
+            uploadCredScan: true
+            uploadFortifySCA: false
+            uploadFxCop: false
+            uploadModernCop: false
+            uploadPoliCheck: false
+            uploadPREfast: false
+            uploadRoslyn: false
+            uploadTSLint: false
+            uploadAsync: true

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -39,32 +39,34 @@ jobs:
     pool:
       name: ${{ parameters.windowsImage }}
     steps:
-      - task: CredScan@2
-        displayName: 'Analyze source for credentials'
-        inputs:
-          toolMajorVersion: 'V2'
-      - task: SdtReport@1
-        displayName: 'Create security analysis report'
-        inputs:
-          AllTools: true
-      - task: PublishSecurityAnalysisLogs@3
-        displayName: 'Publish security analysis logs'
-      - task: TSAUpload@1
-        inputs:
-          tsaVersion: 'TsaV2'
-          codebase: 'NewOrUpdate'
-          tsaEnvironment: 'PROD'
-          codeBaseName: 'XamarinComponents_master'
-          notificationAlias: 'xamacomd@microsoft.com'
-          notifyAlwaysV2: false
-          instanceUrlForTsaV2: 'DEVDIV'
-          projectNameDEVDIV: 'DevDiv'
-          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-          iterationPath: 'DevDiv\OneVS'
-      - task: PostAnalysis@1
-        displayName: 'Analyze security analysis report'
-        inputs:
-          AllTools: true
+      - pwsh: 'echo hello'
+        displayName: '$(Build.Repository.Name)_$(Build.SourceBranchName)'
+#       - task: CredScan@2
+#         displayName: 'Analyze source for credentials'
+#         inputs:
+#           toolMajorVersion: 'V2'
+#       - task: SdtReport@1
+#         displayName: 'Create security analysis report'
+#         inputs:
+#           AllTools: true
+#       - task: PublishSecurityAnalysisLogs@3
+#         displayName: 'Publish security analysis logs'
+#       - task: TSAUpload@1
+#         inputs:
+#           tsaVersion: 'TsaV2'
+#           codebase: 'NewOrUpdate'
+#           tsaEnvironment: 'PROD'
+#           codeBaseName: 'XamarinComponents_master'
+#           notificationAlias: 'xamacomd@microsoft.com'
+#           notifyAlwaysV2: false
+#           instanceUrlForTsaV2: 'DEVDIV'
+#           projectNameDEVDIV: 'DevDiv'
+#           areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+#           iterationPath: 'DevDiv\OneVS'
+#       - task: PostAnalysis@1
+#         displayName: 'Analyze security analysis report'
+#         inputs:
+#           AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -46,32 +46,32 @@ jobs:
           $CODEBASE_NAME = $repo + "_" + $branch
           echo "Using codebase: $CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-      # - task: CredScan@2
-      #   displayName: 'Analyze source for credentials'
-      #   inputs:
-      #     toolMajorVersion: 'V2'
-      # - task: SdtReport@1
-      #   displayName: 'Create security analysis report'
-      #   inputs:
-      #     AllTools: true
-      # - task: PublishSecurityAnalysisLogs@3
-      #   displayName: 'Publish security analysis logs'
-      # - task: TSAUpload@1
-      #   inputs:
-      #     tsaVersion: 'TsaV2'
-      #     codebase: 'NewOrUpdate'
-      #     tsaEnvironment: 'PROD'
-      #     codeBaseName: $(CODEBASE_NAME)
-      #     notificationAlias: 'xamacomd@microsoft.com'
-      #     notifyAlwaysV2: false
-      #     instanceUrlForTsaV2: 'DEVDIV'
-      #     projectNameDEVDIV: 'DevDiv'
-      #     areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-      #     iterationPath: 'DevDiv\OneVS'
-      # - task: PostAnalysis@1
-      #   displayName: 'Analyze security analysis report'
-      #   inputs:
-      #     AllTools: true
+      - task: CredScan@2
+        displayName: 'Analyze source for credentials'
+        inputs:
+          toolMajorVersion: 'V2'
+      - task: SdtReport@1
+        displayName: 'Create security analysis report'
+        inputs:
+          AllTools: true
+      - task: PublishSecurityAnalysisLogs@3
+        displayName: 'Publish security analysis logs'
+      - task: TSAUpload@1
+        inputs:
+          tsaVersion: 'TsaV2'
+          codebase: 'NewOrUpdate'
+          tsaEnvironment: 'PROD'
+          codeBaseName: $(CODEBASE_NAME)
+          notificationAlias: 'xamacomd@microsoft.com'
+          notifyAlwaysV2: false
+          instanceUrlForTsaV2: 'DEVDIV'
+          projectNameDEVDIV: 'DevDiv'
+          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+          iterationPath: 'DevDiv\OneVS'
+      - task: PostAnalysis@1
+        displayName: 'Analyze security analysis report'
+        inputs:
+          AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -270,7 +270,7 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - job: checks
       displayName: 'Run required code checks'
-      # condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+      condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
       pool:
         name: ${{ parameters.windowsImage }}
       steps:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -36,7 +36,7 @@ parameters:
 jobs:
   - job: checks
     displayName: 'Run required code checks'
-    condition: eq('refs/head/${{ parameters.masterBranchName}}', variables['Build.SourceBranch'])
+    condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
     pool:
       name: ${{ parameters.windowsImage }}
     steps:
@@ -47,32 +47,32 @@ jobs:
           $CODEBASE_NAME = $repo + "_" + $branch
           echo "Using codebase: $CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-      # - task: CredScan@2
-      #   displayName: 'Analyze source for credentials'
-      #   inputs:
-      #     toolMajorVersion: 'V2'
-      # - task: SdtReport@1
-      #   displayName: 'Create security analysis report'
-      #   inputs:
-      #     AllTools: true
-      # - task: PublishSecurityAnalysisLogs@3
-      #   displayName: 'Publish security analysis logs'
-      # - task: TSAUpload@1
-      #   inputs:
-      #     tsaVersion: 'TsaV2'
-      #     codebase: 'NewOrUpdate'
-      #     tsaEnvironment: 'PROD'
-      #     codeBaseName: $(CODEBASE_NAME)
-      #     notificationAlias: 'xamacomd@microsoft.com'
-      #     notifyAlwaysV2: false
-      #     instanceUrlForTsaV2: 'DEVDIV'
-      #     projectNameDEVDIV: 'DevDiv'
-      #     areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-      #     iterationPath: 'DevDiv\OneVS'
-      # - task: PostAnalysis@1
-      #   displayName: 'Analyze security analysis report'
-      #   inputs:
-      #     AllTools: true
+      - task: CredScan@2
+        displayName: 'Analyze source for credentials'
+        inputs:
+          toolMajorVersion: 'V2'
+      - task: SdtReport@1
+        displayName: 'Create security analysis report'
+        inputs:
+          AllTools: true
+      - task: PublishSecurityAnalysisLogs@3
+        displayName: 'Publish security analysis logs'
+      - task: TSAUpload@1
+        inputs:
+          tsaVersion: 'TsaV2'
+          codebase: 'NewOrUpdate'
+          tsaEnvironment: 'PROD'
+          codeBaseName: $(CODEBASE_NAME)
+          notificationAlias: 'xamacomd@microsoft.com'
+          notifyAlwaysV2: false
+          instanceUrlForTsaV2: 'DEVDIV'
+          projectNameDEVDIV: 'DevDiv'
+          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+          iterationPath: 'DevDiv\OneVS'
+      - task: PostAnalysis@1
+        displayName: 'Analyze security analysis report'
+        inputs:
+          AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -40,35 +40,37 @@ jobs:
       name: ${{ parameters.windowsImage }}
     steps:
       - pwsh: |
-          $CODEBASE_NAME = "$(Build.Repository.Id)" + "_" + "$(Build.Repository.Name)" + "_" + "$(Build.SourceBranchName)"
-          echo "$CODEBASE_NAME"
+          $repo = "$(Build.Repository.Id)".Replace("/", "_")
+          $branch = "$(Build.SourceBranchName)"
+          $CODEBASE_NAME = $repo + "_" + $branch
+          echo "Using codebase: $CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-#       - task: CredScan@2
-#         displayName: 'Analyze source for credentials'
-#         inputs:
-#           toolMajorVersion: 'V2'
-#       - task: SdtReport@1
-#         displayName: 'Create security analysis report'
-#         inputs:
-#           AllTools: true
-#       - task: PublishSecurityAnalysisLogs@3
-#         displayName: 'Publish security analysis logs'
-#       - task: TSAUpload@1
-#         inputs:
-#           tsaVersion: 'TsaV2'
-#           codebase: 'NewOrUpdate'
-#           tsaEnvironment: 'PROD'
-#           codeBaseName: 'XamarinComponents_master'
-#           notificationAlias: 'xamacomd@microsoft.com'
-#           notifyAlwaysV2: false
-#           instanceUrlForTsaV2: 'DEVDIV'
-#           projectNameDEVDIV: 'DevDiv'
-#           areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-#           iterationPath: 'DevDiv\OneVS'
-#       - task: PostAnalysis@1
-#         displayName: 'Analyze security analysis report'
-#         inputs:
-#           AllTools: true
+      - task: CredScan@2
+        displayName: 'Analyze source for credentials'
+        inputs:
+          toolMajorVersion: 'V2'
+      - task: SdtReport@1
+        displayName: 'Create security analysis report'
+        inputs:
+          AllTools: true
+      - task: PublishSecurityAnalysisLogs@3
+        displayName: 'Publish security analysis logs'
+      - task: TSAUpload@1
+        inputs:
+          tsaVersion: 'TsaV2'
+          codebase: 'NewOrUpdate'
+          tsaEnvironment: 'PROD'
+          codeBaseName: $(CODEBASE_NAME)
+          notificationAlias: 'xamacomd@microsoft.com'
+          notifyAlwaysV2: false
+          instanceUrlForTsaV2: 'DEVDIV'
+          projectNameDEVDIV: 'DevDiv'
+          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+          iterationPath: 'DevDiv\OneVS'
+      - task: PostAnalysis@1
+        displayName: 'Analyze security analysis report'
+        inputs:
+          AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -41,6 +41,7 @@ jobs:
     steps:
       - pwsh: |
           $CODEBASE_NAME = "$(Build.Repository.Id)" + "_" + "$(Build.Repository.Name)" + "_" + "$(Build.SourceBranchName)"
+          echo "$CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
 #       - task: CredScan@2
 #         displayName: 'Analyze source for credentials'

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -267,7 +267,7 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0
           displayName: 'Run component detection'
-          condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
+#           condition: eq('refs/head/${{ parameters.masterBranchName }}', variables['Build.SourceBranch'])
           inputs:
             scanType: 'Register'
             verbosity: 'Verbose'

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -40,12 +40,15 @@ jobs:
       name: ${{ parameters.windowsImage }}
     steps:
       - task: CredScan@2
+        displayName: 'Analyse source for credentials'
         inputs:
           toolMajorVersion: 'V2'
       - task: SdtReport@1
-        displayName: 'Create Security Analysis Report'
+        displayName: 'Create security analysis report'
         inputs:
           CredScan: true
+      - task: PublishSecurityAnalysisLogs@3
+        displayName: 'Publish security analysis logs'
 
   - job: ${{ parameters.name }}
     strategy:

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -36,6 +36,7 @@ parameters:
 jobs:
   - job: checks
     displayName: 'Run required code checks'
+    condition: eq("refs/head/${{ parameters.masterBranchName}}", variables['Build.SourceBranch'])
     pool:
       name: ${{ parameters.windowsImage }}
     steps:
@@ -46,32 +47,32 @@ jobs:
           $CODEBASE_NAME = $repo + "_" + $branch
           echo "Using codebase: $CODEBASE_NAME"
           Write-Host "##vso[task.setvariable variable=CODEBASE_NAME]$CODEBASE_NAME"
-      - task: CredScan@2
-        displayName: 'Analyze source for credentials'
-        inputs:
-          toolMajorVersion: 'V2'
-      - task: SdtReport@1
-        displayName: 'Create security analysis report'
-        inputs:
-          AllTools: true
-      - task: PublishSecurityAnalysisLogs@3
-        displayName: 'Publish security analysis logs'
-      - task: TSAUpload@1
-        inputs:
-          tsaVersion: 'TsaV2'
-          codebase: 'NewOrUpdate'
-          tsaEnvironment: 'PROD'
-          codeBaseName: $(CODEBASE_NAME)
-          notificationAlias: 'xamacomd@microsoft.com'
-          notifyAlwaysV2: false
-          instanceUrlForTsaV2: 'DEVDIV'
-          projectNameDEVDIV: 'DevDiv'
-          areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
-          iterationPath: 'DevDiv\OneVS'
-      - task: PostAnalysis@1
-        displayName: 'Analyze security analysis report'
-        inputs:
-          AllTools: true
+      # - task: CredScan@2
+      #   displayName: 'Analyze source for credentials'
+      #   inputs:
+      #     toolMajorVersion: 'V2'
+      # - task: SdtReport@1
+      #   displayName: 'Create security analysis report'
+      #   inputs:
+      #     AllTools: true
+      # - task: PublishSecurityAnalysisLogs@3
+      #   displayName: 'Publish security analysis logs'
+      # - task: TSAUpload@1
+      #   inputs:
+      #     tsaVersion: 'TsaV2'
+      #     codebase: 'NewOrUpdate'
+      #     tsaEnvironment: 'PROD'
+      #     codeBaseName: $(CODEBASE_NAME)
+      #     notificationAlias: 'xamacomd@microsoft.com'
+      #     notifyAlwaysV2: false
+      #     instanceUrlForTsaV2: 'DEVDIV'
+      #     projectNameDEVDIV: 'DevDiv'
+      #     areaPath: 'DevDiv\Xamarin Tools and SDKs\Components'
+      #     iterationPath: 'DevDiv\OneVS'
+      # - task: PostAnalysis@1
+      #   displayName: 'Analyze security analysis report'
+      #   inputs:
+      #     AllTools: true
 
   - job: ${{ parameters.name }}
     strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ resources:
       type: github
       name: xamarin/XamarinComponents
       endpoint: xamarin
+      ref: refs/heads/dev/sec
 
 jobs:
   - template: .ci/build.yml@components

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,6 @@ resources:
       type: github
       name: xamarin/XamarinComponents
       endpoint: xamarin
-      ref: refs/heads/dev/sec
 
 jobs:
   - template: .ci/build.yml@components


### PR DESCRIPTION
This PR adds some of the required security checks. 

This is not complete as some of the checks need to run as part of an MSBuild operation. As a result, the current format of a separate job is incorrect. That will need some more design - especially since some files for Components Governance are generated at compile time. This is mainly to get the basic CredScan and PoliCheck similar running, as well as to just hook up everyone to TSA.