### PR TITLE
Dagger fix for JavaX.Inject dependency

### DIFF
--- a/Android/GoogleDagger/build.cake
+++ b/Android/GoogleDagger/build.cake
@@ -1,7 +1,7 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
 var DAGGERS_VERSION = "2.25.2";
-var DAGGERS_NUGET_VERSION = DAGGERS_VERSION;
+var DAGGERS_NUGET_VERSION = DAGGERS_VERSION + ".1";
 var DAGGERS_URL = $"http://central.maven.org/maven2/com/google/dagger/dagger/{DAGGERS_VERSION}/dagger-{DAGGERS_VERSION}.jar";
 
 Task ("externals")

--- a/Android/GoogleDagger/source/Dagger/Additions.cs
+++ b/Android/GoogleDagger/source/Dagger/Additions.cs
@@ -1,0 +1,39 @@
+using System;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Dagger.Internal
+{
+    partial class MapFactory
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Dictionary as Java.Lang.Object;
+        }
+    }
+
+    partial class SetFactory
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Collection as Java.Lang.Object;
+        }
+    }
+
+    partial class ProviderOfLazy
+    {
+        public unsafe global::Java.Lang.Object Get()
+        {
+            return Lazy as Java.Lang.Object;
+        }
+    }
+
+    partial class MapProviderFactory : global::Dagger.ILazy, global::Dagger.Internal.IFactory
+    {
+        // This method is explicitly implemented as a member of an instantiated Dagger.ILazy
+        public global::Java.Lang.Object Get()
+        {
+            return Dictionary as global::Java.Lang.Object;
+        }
+    }
+}

--- a/Android/GoogleDagger/source/Dagger/Dagger.csproj
+++ b/Android/GoogleDagger/source/Dagger/Dagger.csproj
@@ -12,19 +12,21 @@
     <RootNamespace>Annotations</RootNamespace>
     <AndroidClassParser>class-parse</AndroidClassParser>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+    <NoWarn>CS0108,CS0109,CS0114,CS0618</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Xamarin.Google.Dagger</PackageId>
     <Title>Google Dagger for Xamarin.Android</Title>
     <PackageDescription>Xamarin.Android bindings for Google Dagger</PackageDescription>
+    <Summary>Xamarin.Android bindings for Google Dagger</Summary>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2106537</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2106538</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>2.25.2</PackageVersion>
+    <PackageVersion>2.25.2.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,6 +41,13 @@
 
   <ItemGroup>
     <Reference Include="Mono.Android" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Additions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Javax.Inject" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Android/GoogleDagger/source/Dagger/Transforms/Metadata.xml
+++ b/Android/GoogleDagger/source/Dagger/Transforms/Metadata.xml
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-	<attr path="/api/package[@name='com.google.dagger.dagger']" name="managedName">Google.Dagger</attr>
+	 <attr path="/api/package[@name='dagger.internal']/class[@name='MapFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetDictionary</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='MapProviderFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetDictionary</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='SetFactory']/method[@name='get' and count(parameter)=0]" name="managedName">GetCollection</attr>
+    <attr path="/api/package[@name='dagger.internal']/class[@name='ProviderOfLazy']/method[@name='get' and count(parameter)=0]" name="managedName">GetLazy</attr>
+    <remove-node path="/api/package[@name='dagger.internal']/class[@name='MapProviderFactory']/implements" />
 </metadata>


### PR DESCRIPTION
This brings back @tuyen-vuduc 's fix to Dagger to depend on JavaX.Inject (now that this package is built and published).