### PR TITLE
Don't use a temp file

### DIFF
--- a/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/RedirectMovedTypes.cs
+++ b/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/RedirectMovedTypes.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Build.TypeRedirector
                     assemblyDefinition.Write(writerParams);
                 }
 
-                // remove any .dll.mdb taht we don't want
+                // remove any .dll.mdb that we don't want
                 TryDelete(assembly + ".mdb");
             }
 

--- a/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/RedirectMovedTypes.cs
+++ b/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/RedirectMovedTypes.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Build.TypeRedirector
                 var readerParams = new ReaderParameters
                 {
                     ReadSymbols = true,
+                    ReadWrite = true,
                     AssemblyResolver = resolver,
                 };
                 using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(assembly, readerParams))
@@ -52,17 +53,11 @@ namespace Xamarin.Build.TypeRedirector
                         WriteSymbols = true,
                         SymbolWriterProvider = new PortablePdbWriterProvider(),
                     };
-                    assemblyDefinition.Write(tempFile, writerParams);
+                    assemblyDefinition.Write(writerParams);
                 }
 
-                // delete the old .dll, .dll.mdb, .pdb
-                TryDelete(assembly);
+                // remove any .dll.mdb taht we don't want
                 TryDelete(assembly + ".mdb");
-                TryDelete(Path.ChangeExtension(assembly, "pdb"));
-
-                // move the new file into its place
-                File.Move(tempFile, assembly);
-                File.Move(Path.ChangeExtension(tempFile, "pdb"), Path.ChangeExtension(assembly, "pdb"));
             }
 
             return true;

--- a/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/Xamarin.Build.TypeRedirector.csproj
+++ b/Util/Xamarin.Build.TypeRedirector/source/Xamarin.Build.TypeRedirector/Xamarin.Build.TypeRedirector.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <PackageId>Xamarin.Build.TypeRedirector</PackageId>
     <Title>Xamarin Build-time Type Redirector</Title>
-    <PackageVersion>0.1.1-preview</PackageVersion>
+    <PackageVersion>0.1.2-preview</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2113302</PackageProjectUrl>


### PR DESCRIPTION
This saves the wrong path in the dll for the pdb, meaning VS can't find the symbols and debug.