### PR TITLE
Updated ARCore to 1.14.0

### DIFF
--- a/Android/ARCore/build.cake
+++ b/Android/ARCore/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var NUGET_VERSION = "1.15.0";
+var NUGET_VERSION = "1.14.0";
 
-var AAR_VERSION = "1.15.0";
+var AAR_VERSION = "1.14.0";
 var AAR_URL = string.Format("https://dl.google.com/dl/android/maven2/com/google/ar/core/{0}/core-{0}.aar", AAR_VERSION);
 var OBJ_VERSION = "0.3.0";
 var OBJ_URL = string.Format("https://oss.sonatype.org/content/repositories/releases/de/javagl/obj/{0}/obj-{0}.jar", OBJ_VERSION);

--- a/Android/ARCore/build.cake
+++ b/Android/ARCore/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var NUGET_VERSION = "1.12.0";
+var NUGET_VERSION = "1.15.0";
 
-var AAR_VERSION = "1.12.0";
+var AAR_VERSION = "1.15.0";
 var AAR_URL = string.Format("https://dl.google.com/dl/android/maven2/com/google/ar/core/{0}/core-{0}.aar", AAR_VERSION);
 var OBJ_VERSION = "0.3.0";
 var OBJ_URL = string.Format("https://oss.sonatype.org/content/repositories/releases/de/javagl/obj/{0}/obj-{0}.jar", OBJ_VERSION);

--- a/Android/ARCore/samples/HelloAR.sln
+++ b/Android/ARCore/samples/HelloAR.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 14.0.23107.0
@@ -32,6 +32,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.12.0
+		version = 1.15.0
 	EndGlobalSection
 EndGlobal

--- a/Android/ARCore/samples/HelloAR.sln
+++ b/Android/ARCore/samples/HelloAR.sln
@@ -32,6 +32,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.14.0
+		version = 1.12.0
 	EndGlobalSection
 EndGlobal

--- a/Android/ARCore/samples/HelloAR.sln
+++ b/Android/ARCore/samples/HelloAR.sln
@@ -32,6 +32,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 1.15.0
+		version = 1.14.0
 	EndGlobalSection
 EndGlobal

--- a/Android/ARCore/samples/HelloAR/HelloAR.csproj
+++ b/Android/ARCore/samples/HelloAR/HelloAR.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>1.15.0</ReleaseVersion>
+    <ReleaseVersion>1.14.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/samples/HelloAR/HelloAR.csproj
+++ b/Android/ARCore/samples/HelloAR/HelloAR.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>1.12.0</ReleaseVersion>
+    <ReleaseVersion>1.15.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/samples/JavaGL/JavaGL.csproj
+++ b/Android/ARCore/samples/JavaGL/JavaGL.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>1.15.0</ReleaseVersion>
+    <ReleaseVersion>1.14.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/samples/JavaGL/JavaGL.csproj
+++ b/Android/ARCore/samples/JavaGL/JavaGL.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>1.12.0</ReleaseVersion>
+    <ReleaseVersion>1.15.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/source/Google.ARCore.csproj
+++ b/Android/ARCore/source/Google.ARCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
-    <ReleaseVersion>1.12.0</ReleaseVersion>
+    <ReleaseVersion>1.15.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Android/ARCore/source/Google.ARCore.csproj
+++ b/Android/ARCore/source/Google.ARCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
-    <ReleaseVersion>1.15.0</ReleaseVersion>
+    <ReleaseVersion>1.14.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
This change updates ARCore bindings to version 1.14.0 (based on #629). I have run the HelloAR sample app and verified that it works correctly. Let me know if I need to do any other validation.

Since the Sceneform projects depend on the ARCore NuGet package, I'll follow up with updates to the Sceneform bindings separately once the ARCore 1.14.0 NuGet package is available.

This PR should go in before #794 - I'm doing both so that we can bump Azure Spatial Anchors to 1.14.0 now, and also have 1.15.0 ready (for when ARFoundation supports it).