### PR TITLE
[Guava] Change guava.jar to ReferenceJar + AndroidJavaLibrary

### DIFF
--- a/Android/Guava/source/Guava/Guava.targets
+++ b/Android/Guava/source/Guava/Guava.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <EmbeddedReferenceJar Include="$(MSBuildThisFileDirectory)*.jar" />
+    <ReferenceJar Condition=" '$(AndroidApplication)' != 'true' " Include="$(MSBuildThisFileDirectory)*.jar" />
+    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)*.jar" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/pull/830
Partially reverts: 362ed6a0e748bdd3288614b018bd62bdd7abab56
Context: https://github.com/xamarin/AndroidX/issues/74
Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/308

While considering the best way to add a ProGuard configuration file to
the Xamarin.Google.Guava NuGet package, I realized that the NuGet
package was set up unusually.

Normally, when one NuGet package depends on another NuGet package, the
consuming NuGet package does not repackage the contents of the
dependency.  Instead, the final consuming application is expected to
reference both NuGet packages, either directly or transitively.

For the last couple of versions, the Xamarin.Google.Guava NuGet package
has been breaking this convention.  Those recent versions include a
`.targets` file that sets `guava.jar` to be an `@(EmbeddedReferenceJar)`
in any bindings library that references Xamarin.Google.Guava.  This
means that `guava.jar` is repackaged into the output assembly of the
bindings library.  As a result, any downstream app that consumes the
bindings library does not need to follow the normal convention of
referencing the Xamarin.Google.Guava NuGet package.  This seems likely
to cause confusion, and it also makes it awkward to include a ProGuard
configuration file in the NuGet package.

To resolve this, revert back to the approach from commit 14a3ada3 where
the `.targets` file was setting `guava.jar` to be a `@(ReferenceJar)`
instead of an `@(EmbeddedReferenceJar)`, but this time, also include
`guava.jar` as an `@(AndroidJavaLibrary)` for application projects.

When a bindings project references the NuGet package, the
`@(ReferenceJar)` item type tells the build process to reference
`guava.jar` but not repackage it into the output assembly.

When an application project references the NuGet package, the
`@(AndroidJavaLibrary)` item type tells the build process to package
`guava.jar` as part of the application.

I locally verified that the new `.targets` file worked correctly for
both of these scenarios.

The problem with the original approach in commit 14a3ada3 was that it
only included the `guava.jar` file as a `@(ReferenceJar)` item.  That
worked for bindings projects, but it didn't work for application
projects because application projects ignore the `@(ReferenceJar)` item
type.  One place this problem surfaced was in app builds using R8, as
seen in xamarin/AndroidX#74:

	R8 : warning : Missing class: com.google.common.util.concurrent.FutureCallback
	R8 : error : Compilation can't be completed because some library classes are missing.

Another place the problem surfaced was in running apps, as seen in
xamarin/GooglePlayServicesComponents#308:

	Java.Lang.NoClassDefFoundError: Failed resolution of: Lcom/google/common/base/Preconditions;

Admittedly, the only NuGet package maintained by the Xamarin team that
still references Xamarin.Google.Guava in the latest published version is
Xamarin.Firebase.Firestore, so there probably aren't too many apps that
need `guava.jar`, but it still seems like it would be nice to fix the
unconventional behavior so that Xamarin.Google.Guava can provide a
ProGuard configuration file for those apps.

Note that Xamarin.AndroidX.Room.Guava version 2.0.0 also referenced
Xamarin.Google.Guava, but the latest vesrion 2.2.5 does not because
androidx.room:room-guava [has switched][0] from Guava to the smaller
androix.concurrent:concurrent-futures library.  A likely motivation
behind that change is that the full Guava library is fairly large.

[0]: https://android.googlesource.com/platform/frameworks/support/+/2d074149f0430223ea9db69b268f6bcfeb1d4b4a%5E!