### PR TITLE
TensorFlow-Lite 1.15

### DIFF
--- a/XPlat/TensorFlow.Lite/build.cake
+++ b/XPlat/TensorFlow.Lite/build.cake
@@ -1,8 +1,8 @@
 
 var TARGET = Argument("t", Argument("target", "Default"));
 
-var NUGET_VERSION = "1.14.0";
-var AAR_VERSION = "1.14.0";
+var NUGET_VERSION = "1.15.0";
+var AAR_VERSION = "1.15.0";
 var NUGET_PACKAGE_ID = "Xamarin.TensorFlow.Lite";
 var AAR_URL_01 = $"https://bintray.com/google/tensorflow/download_file?file_path=org%2Ftensorflow%2Ftensorflow-lite%2F{AAR_VERSION}%2Ftensorflow-lite-{AAR_VERSION}.aar";
 var AAR_URL_02 = $"https://bintray.com/google/tensorflow/download_file?file_path=org%2Ftensorflow%2Ftensorflow-lite-gpu%2F{AAR_VERSION}%2Ftensorflow-lite-gpu-{AAR_VERSION}.aar";

--- a/XPlat/TensorFlow.Lite/build.cake
+++ b/XPlat/TensorFlow.Lite/build.cake
@@ -1,5 +1,5 @@
 
-var TARGET = Argument("t", Argument("target", "Default"));
+var TARGET = Argument("t", Argument("target", "ci"));
 
 var NUGET_VERSION = "1.15.0";
 var AAR_VERSION = "1.15.0";
@@ -44,5 +44,9 @@ Task("clean")
 	if (DirectoryExists("./externals/"))
 		DeleteDirectory("./externals", true);
 });
+
+Task("ci")
+	.IsDependentOn("libs")
+	.IsDependentOn("nuget");
 
 RunTarget(TARGET);

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Transforms/Metadata.xml
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Transforms/Metadata.xml
@@ -1,14 +1,28 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-	<!--
+  <!--
   This sample removes the class: android.support.v4.content.AsyncTaskLoader.LoadTask:
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='AsyncTaskLoader.LoadTask']" />
   
   This sample removes the method: android.support.v4.content.CursorLoader.loadInBackground:
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='CursorLoader']/method[@name='loadInBackground']" />
   -->
-    <attr 
-        path="/api/package[@name='org.tensorflow.lite']" name="managedName" >
-        Xamarin.TensorFlow.Lite
-    </attr>
+  <attr
+      path="/api/package[@name='org.tensorflow.lite']"
+      name="managedName"
+        >
+    Xamarin.TensorFlow.Lite
+  </attr>
+  <attr
+      path="/api/package[@name='org.tensorflow.lite.nnapi']"
+      name="managedName"
+        >
+    Xamarin.TensorFlow.Lite.Nnapi
+  </attr>
+  <attr
+      path="/api/package[@name='org.tensorflow.lite.annotations']"
+      name="managedName"
+        >
+    Xamarin.TensorFlow.Lite.Annotations
+  </attr>
 </metadata>

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid.csproj
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid.csproj
@@ -24,7 +24,7 @@
         -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Xamarin.TensorFlow.Lite</PackageId>
-        <PackageVersion>1.14.0</PackageVersion>
+        <PackageVersion>1.15.0</PackageVersion>
         <Title>Xamarin.TensorFlow.Lite</Title>
         <PackageDescription>
             Bindings for Google's TensorFlow Lite package (Google Play Services dependency)

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Transforms/Metadata.xml
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Transforms/Metadata.xml
@@ -1,20 +1,17 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-	<!--
+  <!--
   This sample removes the class: android.support.v4.content.AsyncTaskLoader.LoadTask:
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='AsyncTaskLoader.LoadTask']" />
   
   This sample removes the method: android.support.v4.content.CursorLoader.loadInBackground:
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='CursorLoader']/method[@name='loadInBackground']" />
   -->
-    <attr 
-        path="/api/package[@name='org.tensorflow.lite']" name="managedName" >
-        Xamarin.TensorFlow.Lite
-    </attr>
-    <attr 
-        path="/api/package[@name='org.tensorflow.lite.nnapi']" 
-        name="managedName" 
+  <attr
+    path="/api/package[@name='org.tensorflow.lite.gpu']"
+    name="managedName"
         >
-        Xamarin.TensorFlow.Lite.Nnapi
-    </attr>
+    Xamarin.TensorFlow.Lite.GPU
+  </attr>
+
 </metadata>

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid.csproj
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid.csproj
@@ -24,7 +24,7 @@
         -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Xamarin.TensorFlow.Lite.Gpu</PackageId>
-        <PackageVersion>1.14.0</PackageVersion>
+        <PackageVersion>1.15.0</PackageVersion>
         <Title>Xamarin.TensorFlow.Lite.Gpu</Title>
         <PackageDescription>
             Bindings for Google's TensorFlow Lite GPU package (Google Play Services dependency)


### PR DESCRIPTION
build.cake:

*    artifact and nuget version bumped from 1.14 to 1.15.0
*    `Default` target changed to `ci`

Metadata.xml

*    re-checked packagenames (namespaces) and fixed differences (1 new namespace added)
*    no new warnings and errors, so no new metadata was necessary
