### PR TITLE
Fix for silent Windows builds failuers because of CocoaPods

### DIFF
--- a/XPlat/Chromium.CroNet/build.cake
+++ b/XPlat/Chromium.CroNet/build.cake
@@ -65,20 +65,24 @@ Task ("externals")
 			}
 
 			EnsureDirectoryExists("./externals/ios");
-			if (CocoaPodVersion () < new System.Version (1, 0))
+
+			if ( ! IsRunningOnWindows() )
 			{
-				CocoaPods.RemoveAt (1);
+				if (CocoaPodVersion () < new System.Version (1, 0))
+				{
+					CocoaPods.RemoveAt (1);
+				}
+
+				FileWriteLines ("./externals/ios/Podfile", CocoaPods.ToArray ());
+				
+				CocoaPodRepoUpdate ();
+
+				CocoaPodInstall 
+					(
+						"./externals/ios/", 
+						new CocoaPodInstallSettings { NoIntegrate = true }
+					);
 			}
-
-			FileWriteLines ("./externals/ios/Podfile", CocoaPods.ToArray ());
-			
-			CocoaPodRepoUpdate ();
-
-			CocoaPodInstall 
-				(
-					"./externals/ios/", 
-					new CocoaPodInstallSettings { NoIntegrate = true }
-				);
 			
 			return;
 		}


### PR DESCRIPTION
Windows builds fail silently on DevOps and there are no nugets to sign. This prevents CocoaPods failure in Cake script

```
if ( ! IsRunningOnWindows() )
```