### PR TITLE
ci targets added to manifest.yml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -281,6 +281,8 @@
 - Name: Google.Android.DataTransport
   BuildScript: ./Android/Google.Android.DataTransport/build.cake
   TriggerPaths: [ Android/Google.Android.DataTransport ]
+  MacBuildTargets: [ ci ]
+  WindowsBuildTargets: [ ci ]
 - Name:  CheckerFramework.Checker
   BuildScript: ./Android/CheckerFramework.Checker/build.cake
   TriggerPaths: [ Android/CheckerFramework.Checker ]


### PR DESCRIPTION
Seems like packaging and publishing does not work with default or no target at all, so added targets to manifest.yml