### PR TITLE
Io.PerfMark 0.19.0 version bump

### DIFF
--- a/Android/Io.PerfMark/build.cake
+++ b/Android/Io.PerfMark/build.cake
@@ -7,7 +7,7 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-string ARTIFACT_VERSION="0.17.0";
+string ARTIFACT_VERSION="0.19.0";
 string JAR_URL = "";
 Dictionary<string, string> JAR_URLS_ARTIFACT_FILES= new Dictionary<string, string>()
 {

--- a/Android/Io.PerfMark/source/Xamarin.Io.PerfMark.PerfMarkApi/Xamarin.Io.PerfMark.PerfMarkApi.csproj
+++ b/Android/Io.PerfMark/source/Xamarin.Io.PerfMark.PerfMarkApi/Xamarin.Io.PerfMark.PerfMarkApi.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Xamarin.Io.PerfMark.PerfMarkApi</PackageId>
-    <PackageVersion>0.17.0</PackageVersion>
+    <PackageVersion>0.19.0</PackageVersion>
     <Title>Xamarin.Io.PerfMark.PerfMarkApi</Title>
     <PackageDescription>Bindings for Io.PerfMark.PerfMarkApi package (Google GRPC  dependency)</PackageDescription>
     <Owners>Microsoft</Owners>
@@ -44,8 +44,8 @@
     <Folder Include="Jars\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedJar Include="..\..\externals\android\opencensus-api-0.17.0.jar">
-      <Link>Jars\opencensus-api-0.17.0.jar</Link>
+    <EmbeddedJar Include="..\..\externals\android\opencensus-api-$(PackageVersion).jar">
+      <Link>Jars\opencensus-api-0.$(PackageVersion).0.jar</Link>
     </EmbeddedJar>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Io.PerfMark 0.19.0 version bump (needed for Google.GRPC packages)