### PR TITLE
TensorFlow.Lite 2.0.0.1 fix for issue 876

### DIFF
--- a/XPlat/TensorFlow.Lite/build.cake
+++ b/XPlat/TensorFlow.Lite/build.cake
@@ -1,8 +1,8 @@
 
 var TARGET = Argument("t", Argument("target", "ci"));
 
-var NUGET_VERSION = "1.15.0.1";
-var AAR_VERSION = "1.15.0";
+var NUGET_VERSION = "2.0.0.1";
+var AAR_VERSION = "2.0.0";
 
 var NUGET_PACKAGE_ID = "Xamarin.TensorFlow.Lite";
 var AAR_URL_01 = $"https://bintray.com/google/tensorflow/download_file?file_path=org%2Ftensorflow%2Ftensorflow-lite%2F{AAR_VERSION}%2Ftensorflow-lite-{AAR_VERSION}.aar";

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid.csproj
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Bindings.XamarinAndroid.csproj
@@ -24,7 +24,7 @@
         -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Xamarin.TensorFlow.Lite</PackageId>
-        <PackageVersion>1.15.0.1</PackageVersion>
+        <PackageVersion>2.0.0.1</PackageVersion>
         <Title>Xamarin.TensorFlow.Lite</Title>
         <PackageDescription>
             Bindings for Google's TensorFlow Lite package (Google Play Services dependency)

--- a/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid.csproj
+++ b/XPlat/TensorFlow.Lite/source/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid/Xamarin.TensorFlow.Lite.Gpu.Bindings.XamarinAndroid.csproj
@@ -24,7 +24,7 @@
         -->
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Xamarin.TensorFlow.Lite.Gpu</PackageId>
-        <PackageVersion>1.15.0.1</PackageVersion>
+        <PackageVersion>2.0.0.1</PackageVersion>
         <Title>Xamarin.TensorFlow.Lite.Gpu</Title>
         <PackageDescription>
             Bindings for Google's TensorFlow Lite GPU package (Google Play Services dependency)


### PR DESCRIPTION
2.0.0.1 BuildAction fixes + project reference fix

https://github.com/xamarin/XamarinComponents/issues/876

Fixed:

BuildAction
ProjectReference - missed MCW classes because of that