### PR TITLE
Add Xamarin.Firebase.Messaging as Notification Hubs Dependency

### DIFF
--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" PrivateAssets="None" />
+    <PackageReference Include="Xamarin.Firebase.Messaging" Version="71.1740.1" />
   </ItemGroup>
 
 </Project>

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-    <TargetFramework>MonoAndroid80</TargetFramework>
+    <TargetFramework>MonoAndroid90</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Azure.NotificationHubs.Android</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>


### PR DESCRIPTION
PR 1 of 2

It's come to our attention that the existing Android Notification Hub sample is inoperable. The trouble is a missing Xamarin wrapper of the `FirebaseReceiver` type. The fix is fairly simple, add the dependency to Xamarin.Firebase.Messaging necessary for the Receiver to be discovered and emitted when building the binding library.

To fully remedy the situation, we'll also need to update the Sample Application to target the new binary. I've confirmed locally that once these changes are made, that we can initialize Firebase and receive notifications to the device. However, because the sample takes a dependency on the NuGet version of this package, we must break this into two PRs.