### PR TITLE
Update AzureMessaging Android Bindings

### DIFF
--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -4,8 +4,8 @@ var IOS_VERSION = "3.0.0-preview2";
 var IOS_NUGET_VERSION = "3.0.0-preview2";
 var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging.framework.zip";
 
-var ANDROID_VERSION = "1.0.0-preview2";
-var ANDROID_NUGET_VERSION = "1.0.0-preview2.1";
+var ANDROID_VERSION = "1.0.0-preview3";
+var ANDROID_NUGET_VERSION = "1.0.0-preview3";
 var ANDROID_URL = string.Format ("https://dl.bintray.com/microsoftazuremobile/SDK/com/microsoft/azure/notification-hubs-android-sdk/{0}/notification-hubs-android-sdk-{0}.aar", ANDROID_VERSION);
 
 Task("libs-ios")


### PR DESCRIPTION
Updates the external dependency on the Azure Notification Hubs Android AAR to reference [1.0.0-preview3](https://github.com/Azure/azure-notificationhubs-android/releases/tag/v1.0.0-preview3).