### PR TITLE
Update AzureMessaging iOS from v3.0.0-preview2 to v3.0.0-preview3

### DIFF
--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
     <TargetFramework>MonoAndroid90</TargetFramework>

--- a/XPlat/AzureMessaging/README.md
+++ b/XPlat/AzureMessaging/README.md
@@ -20,13 +20,13 @@ const string HUB_NAME = "YOUR-HUB-NAME";
 
 After that initialize the Hub and ensure your device is registered by adding the following code to your `FinishedLaunching` override in your `AppDelegate`:
 ```
-	SNotificationHub.Init(CONNECTION_STRING, HUB_NAME);
+	SNotificationHub.Start(CONNECTION_STRING, HUB_NAME);
 	Console.WriteLine("Device Token: " + MSNotificationHub.GetPushChannel());
 ```
 
 To receive notification on your device you should:
 
-1. Add class which implements `IMSNotificationHubDelegate`
+1. Add class which inherits `MSNotificationHubDelegate`
 2. Add implementation for `IMSNotificationHubDelegate.DidReceivePushNotification`
 ```
 public void DidReceivePushNotification(MSNotificationHub notificationHub, MSNotificationHubMessage message)

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -131,6 +131,10 @@ Task ("externals-ios")
 
 	Unzip ("./iOS/externals/sdk.zip", "./iOS/externals");
 	
+	CopyFile(
+		"./iOS/externals/WindowsAzureMessaging-SDK-Apple/iOS/WindowsAzureMessaging.framework/WindowsAzureMessaging",
+		"./iOS/externals/WindowsAzureMessaging.a");
+
 	XmlPoke("./iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj", "/Project/PropertyGroup/PackageVersion", IOS_NUGET_VERSION);
 });
 

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var IOS_VERSION = "3.0.0-preview2";
-var IOS_NUGET_VERSION = "3.0.0-preview2";
-var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging.framework.zip";
+var IOS_VERSION = "3.0.0-preview3";
+var IOS_NUGET_VERSION = "3.0.0-preview3";
+var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging-SDK-Apple-{IOS_VERSION}.zip";
 
 var ANDROID_VERSION = "1.0.0-preview2";
 var ANDROID_NUGET_VERSION = "1.0.0-preview2.1";

--- a/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/AppDelegate.cs
+++ b/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/AppDelegate.cs
@@ -35,7 +35,7 @@ namespace AzureMessagingSampleiOS
 			// If you have defined a root view controller, set it here:
 			window.RootViewController = homeViewController;
 
-			MSNotificationHub.Init(CONNECTION_STRING, HUB_NAME);
+			MSNotificationHub.Start(CONNECTION_STRING, HUB_NAME);
 
 			Console.WriteLine("Device Token: " + MSNotificationHub.GetPushChannel());
 
@@ -48,7 +48,7 @@ namespace AzureMessagingSampleiOS
 		}       
 	}
 
-	public partial class NotificationListener : NSObject, IMSNotificationHubDelegate
+	public partial class NotificationListener : MSNotificationHubDelegate
 	{
 		HomeViewController homeViewController;
 
@@ -58,14 +58,12 @@ namespace AzureMessagingSampleiOS
 
 		}
 
-        public void DidReceivePushNotification(MSNotificationHub notificationHub, MSNotificationHubMessage message, CompletionHandler completionHandler)
+        public override void DidReceivePushNotification(MSNotificationHub notificationHub, MSNotificationHubMessage message)
         {
 			homeViewController.ProcessNotification(message.Title, message.Body);
 
 			Console.WriteLine("Notification Title: " + message.Title);
 			Console.WriteLine("Notification Body: " + message.Body);
-
-			completionHandler(UIBackgroundFetchResult.NoData);
 		}
 	}
 }

--- a/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/HomeViewController.cs
+++ b/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/HomeViewController.cs
@@ -16,9 +16,11 @@ namespace AzureMessagingSampleiOS
 
 		public void ProcessNotification (string title, string message)
 		{
-			InvokeOnMainThread (() => {
-				var av = new UIAlertView (title, message, null, "OK");
-				av.Show ();
+			InvokeOnMainThread(() => {
+				var avc = UIAlertController.Create(title, message, UIAlertControllerStyle.Alert);
+				var action = UIAlertAction.Create("OK", UIAlertActionStyle.Cancel, null);
+				avc.AddAction(action);
+				PresentViewController(avc, true, null);
 			});
 		}
 	}

--- a/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/Info.plist
+++ b/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/Info.plist
@@ -11,7 +11,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>13.0</string>
+	<string>9.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/NotificationHubsSample.csproj
+++ b/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/NotificationHubsSample.csproj
@@ -22,7 +22,12 @@
     <MtouchLink>None</MtouchLink>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
-    <MtouchArch>ARM64</MtouchArch>
+    <MtouchFastDev>true</MtouchFastDev>
+    <MtouchLink>None</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
+    <DeviceSpecificBuild>false</DeviceSpecificBuild>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
@@ -30,10 +35,12 @@
     <DefineConstants>__MOBILE__;__IOS__;__UNIFIED__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>None</MtouchLink>
     <ConsolePause>false</ConsolePause>
+    <MtouchLink>Full</MtouchLink>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,12 +51,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <IpaPackageName>
-    </IpaPackageName>
-    <MtouchArch>ARM64</MtouchArch>
+    <MtouchFastDev>false</MtouchFastDev>
+    <MtouchFloat32>true</MtouchFloat32>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
@@ -57,35 +67,12 @@
     <DefineConstants>__MOBILE__;__IOS__;__UNIFIED__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <MtouchFloat32>true</MtouchFloat32>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchArch>ARM64</MtouchArch>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
-    <DefineConstants>__MOBILE__;__IOS__;__UNIFIED__</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <BuildIpa>true</BuildIpa>
-    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
-    <MtouchArch>ARM64</MtouchArch>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
-    <Optimize>true</Optimize>
-    <OutputPath>bin\iPhone\AppStore</OutputPath>
-    <DefineConstants>__MOBILE__;__IOS__;__UNIFIED__</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignProvision>Automatic:AppStore</CodesignProvision>
-    <CodesignKey>iPhone Distribution</CodesignKey>
-    <MtouchArch>ARM64</MtouchArch>
+    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
+    <MtouchTlsProvider>Default</MtouchTlsProvider>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreNoCache>true</RestoreNoCache>

--- a/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/NotificationHubsSample.csproj
+++ b/XPlat/AzureMessaging/iOS/samples/NotificationHubsSample/NotificationHubsSample.csproj
@@ -22,6 +22,7 @@
     <MtouchLink>None</MtouchLink>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <Optimize>true</Optimize>
@@ -32,6 +33,7 @@
     <MtouchLink>None</MtouchLink>
     <ConsolePause>false</ConsolePause>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,6 +49,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <IpaPackageName>
     </IpaPackageName>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <Optimize>true</Optimize>
@@ -57,6 +60,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <Optimize>true</Optimize>
@@ -69,6 +73,7 @@
     <BuildIpa>true</BuildIpa>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <Optimize>true</Optimize>
@@ -80,6 +85,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchArch>ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreNoCache>true</RestoreNoCache>
@@ -105,7 +111,7 @@
     <Compile Include="HomeViewController.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Azure.NotificationHubs.iOS" Version="3.0.0-preview2" />
+    <PackageReference Include="Xamarin.Azure.NotificationHubs.iOS" Version="3.0.0-preview3" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/XPlat/AzureMessaging/iOS/source/ApiDefinition.cs
+++ b/XPlat/AzureMessaging/iOS/source/ApiDefinition.cs
@@ -280,7 +280,6 @@ namespace WindowsAzure.Messaging.NotificationHubs
 		NSDictionary<NSString, NSString> UserInfo { get; }
 	}
 
-	[BaseType(typeof(NSObject))]
 	[Protocol]
 	public interface MSChangeTracking
 	{
@@ -288,12 +287,11 @@ namespace WindowsAzure.Messaging.NotificationHubs
 		bool IsDirty();
 	}
 
-	[BaseType(typeof(NSObject))]
 	[Protocol]
 	public interface MSTaggable
 	{
-		[Abstract, Export("getTags")]
-		NSArray<NSString> Tags { get; }
+		[Abstract, Export("tags")]
+		NSSet<NSString> Tags { get; }
 
 		[Abstract, Export("addTag:")]
 		bool AddTag(string tag);

--- a/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
+++ b/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
@@ -21,7 +21,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864962</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865062</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>3.0.0-preview2</PackageVersion>
+    <PackageVersion>3.0.0-preview3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,9 +31,8 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
-  
   <ItemGroup>
-    <None Include="..\externals\WindowsAzureMessaging.framework">
+    <None Include="..\externals\WindowsAzureMessaging-SDK-Apple\iOS\WindowsAzureMessaging.framework">
       <Link>WindowsAzureMessaging.framework</Link>
     </None>
     <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />

--- a/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
+++ b/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
@@ -31,19 +31,13 @@
   <ItemGroup>
     <Folder Include="Resources\" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="..\externals\WindowsAzureMessaging-SDK-Apple\iOS\WindowsAzureMessaging.framework">
-      <Link>WindowsAzureMessaging.framework</Link>
-    </None>
-    <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
-  </ItemGroup>
 
   <ItemGroup>
-    <NativeReference Include="..\externals\WindowsAzureMessaging.framework">
-      <Kind>Framework</Kind>
-      <Frameworks>Security UserNotifications SystemConfiguration Foundation UIKit</Frameworks>
-      <LinkerFlags>-ObjC -lc++</LinkerFlags>
-      <ForceLoad>True</ForceLoad>
+    <NativeReference Include="..\externals\WindowsAzureMessaging.a">
+      <Kind>Static</Kind>
+      <SmartLink>false</SmartLink>
+      <Frameworks>Security SystemConfiguration Foundation UIKit</Frameworks>
+      <WeakFrameworks>UserNotifications</WeakFrameworks>
     </NativeReference>
   </ItemGroup>
 


### PR DESCRIPTION
This updates the XPlat AzureMessaging Xamarin Component for iOS to use 3.0.0-preview3.  This includes breaking changes to the callback and initialization.  The readme and sample application have been updated.