### PR TITLE
[EN] Correct the units for iOS exposure duration

### DIFF
--- a/XPlat/ExposureNotification/build.cake
+++ b/XPlat/ExposureNotification/build.cake
@@ -1,7 +1,7 @@
 var TARGET = Argument("t", Argument("target", "ci"));
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
-var NUGET_VERSION = "0.11.0-preview";
+var NUGET_VERSION = "0.12.0-preview";
 
 Task("nuget")
 	.Does(() =>

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -275,7 +275,7 @@ namespace Xamarin.ExposureNotifications
 
 						return new ExposureInfo(
 							((DateTime)i.Date).ToLocalTime(),
-							TimeSpan.FromMinutes(i.Duration),
+							TimeSpan.FromSeconds(i.Duration),
 							i.AttenuationValue,
 							totalRisk,
 							i.TransmissionRiskLevel.FromNative());


### PR DESCRIPTION
- The docs for the property says minutes. The docs for the property type say seconds. The value appears to be seconds.
- Fixes #919