### PR TITLE
Upgrade AzureMessaging iOS from Preview3 to Preview4

### DIFF
--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -26,7 +26,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864958</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=864960</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.0.0-preview2.1</PackageVersion>
+    <PackageVersion>1.0.0-preview3</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -1,7 +1,7 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var IOS_VERSION = "3.0.0-preview3";
-var IOS_NUGET_VERSION = "3.0.0-preview3";
+var IOS_VERSION = "3.0.0-preview4";
+var IOS_NUGET_VERSION = "3.0.0-preview4";
 var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging-SDK-Apple-{IOS_VERSION}.zip";
 
 var ANDROID_VERSION = "1.0.0-preview3";

--- a/XPlat/AzureMessaging/iOS/source/ApiDefinition.cs
+++ b/XPlat/AzureMessaging/iOS/source/ApiDefinition.cs
@@ -199,6 +199,9 @@ namespace WindowsAzure.Messaging.NotificationHubs
 		[Static, Export("getInstallationId")]
 		string GetInstallationId();
 
+		[Static, Export("willSaveInstallation")]
+		void WillSaveInstallation();
+
 		[Static, Export("addTag:")]
 		bool AddTag(string tag);
 

--- a/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
+++ b/XPlat/AzureMessaging/iOS/source/Xamarin.Azure.NotificationHubs.iOS.csproj
@@ -21,7 +21,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864962</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865062</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>3.0.0-preview3</PackageVersion>
+    <PackageVersion>3.0.0-preview4</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a small update to support Preview 4 for the Azure Notification Hubs SDK for Apple.