### PR TITLE
Upgrade Xamarin.Google.Dagger to 2.27.0.

### DIFF
--- a/Android/GoogleDagger/build.cake
+++ b/Android/GoogleDagger/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var DAGGERS_VERSION = "2.25.2";
-var DAGGERS_NUGET_VERSION = DAGGERS_VERSION + ".1";
-var DAGGERS_URL = $"http://central.maven.org/maven2/com/google/dagger/dagger/{DAGGERS_VERSION}/dagger-{DAGGERS_VERSION}.jar";
+var DAGGERS_VERSION = "2.27";
+var DAGGERS_NUGET_VERSION = DAGGERS_VERSION + ".0";
+var DAGGERS_URL = $"https://repo1.maven.org/maven2/com/google/dagger/dagger/{DAGGERS_VERSION}/dagger-{DAGGERS_VERSION}.jar";
 
 Task ("externals")
 	.WithCriteria (!FileExists ("./externals/dagger.jar"))

--- a/Android/GoogleDagger/source/Dagger/Dagger.csproj
+++ b/Android/GoogleDagger/source/Dagger/Dagger.csproj
@@ -26,7 +26,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2106537</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2106538</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>2.25.2.1</PackageVersion>
+    <PackageVersion>2.27.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade Xamarin.Google.Dagger to 2.27.0.

This is required for GPS July 2020 updates.

Note:
`http://central.maven.org` no longer seems to exist, so I replaced it with `https://repo1.maven.org`.