### PR TITLE
Upgrade Xamarin.Google.AutoValue.Annotations to 1.6.6.

### DIFF
--- a/Android/GoogleAutoValue/build.cake
+++ b/Android/GoogleAutoValue/build.cake
@@ -3,9 +3,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
-var ANNOTATIONS_VERSION = "1.6.5";
+var ANNOTATIONS_VERSION = "1.6.6";
 var ANNOTATIONS_NUGET_VERSION = ANNOTATIONS_VERSION;
-var ANNOTATIONS_URL = $"http://central.maven.org/maven2/com/google/auto/value/auto-value-annotations/{ANNOTATIONS_VERSION}/auto-value-annotations-{ANNOTATIONS_VERSION}.jar";
+var ANNOTATIONS_URL = $"https://repo1.maven.org/maven2/com/google/auto/value/auto-value-annotations/{ANNOTATIONS_VERSION}/auto-value-annotations-{ANNOTATIONS_VERSION}.jar";
 
 Task ("externals")
 	.WithCriteria (!FileExists ("./externals/auto-value-annotations.jar"))
@@ -60,5 +60,13 @@ Task ("clean")
 			Force = true
 		});
 });
+
+Task("ci")
+	.IsDependentOn("libs")
+	.IsDependentOn("nuget")
+	.Does
+	(
+		() => {}
+	);
 
 RunTarget (TARGET);

--- a/Android/GoogleAutoValue/source/Annotations/Annotations.csproj
+++ b/Android/GoogleAutoValue/source/Annotations/Annotations.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2091414</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=2091801</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.6.5</PackageVersion>
+    <PackageVersion>1.6.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade Xamarin.Google.AutoValue.Annotations to 1.6.6.

This is required for GPS July 2020 updates.

Note:
`http://central.maven.org` no longer seems to exist, so I replaced it with `https://repo1.maven.org`.