### PR TITLE
[binderator] Fix issue with single digit versions.

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -276,6 +276,8 @@ namespace AndroidBinderator
 					if (!string.IsNullOrEmpty(mavenDep.Scope) && !mavenDep.Scope.ToLowerInvariant().Equals("compile"))
 						continue;
 
+					mavenDep.Version = FixVersion(mavenDep.Version);
+
 					var depMapping = config.MavenArtifacts.FirstOrDefault(
 						ma => !string.IsNullOrEmpty(ma.Version) 
 						&& ma.GroupId == mavenDep.GroupId
@@ -335,6 +337,20 @@ namespace AndroidBinderator
 				}
 			}
 			return dest;
+		}
+
+		// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
+		// Fix them to be "1.0".
+		// https://github.com/NuGet/Home/issues/10342
+		static string FixVersion(string version)
+		{
+			if (string.IsNullOrWhiteSpace(version))
+				return version;
+
+			if (!version.Contains("."))
+				version += ".0";
+
+			return version;
 		}
 	}
 }

--- a/Util/Xamarin.AndroidBinderator/build.cake
+++ b/Util/Xamarin.AndroidBinderator/build.cake
@@ -37,4 +37,7 @@ Task("Default")
 	.IsDependentOn("nuget")
 	.IsDependentOn("tests");
 
+Task("ci")
+	.IsDependentOn("Default");
+
 RunTarget(TARGET);


### PR DESCRIPTION
There is an issue with `VersionRage.Parse` being unable to parse single digit versions:
```
Unhandled exception. System.ArgumentException: '1' is not a valid version string.
   at NuGet.Versioning.VersionRange.Parse(String value, Boolean allowFloating)
   at MavenNet.MavenVersionRange.Satisfies(String version)
   at MavenNet.Models.Dependency.Satisfies(String version)
   at AndroidBinderator.Engine.<>c__DisplayClass4_0.<BuildProjectModels>b__0(MavenArtifactConfig ma) in D:\a\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 279
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at AndroidBinderator.Engine.BuildProjectModels(BindingConfig config, TemplateConfig template, Dictionary`2 mavenProjects) in D:\a\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 275
   at AndroidBinderator.Engine.ProcessConfig(MavenRepository maven, BindingConfig config) in D:\a\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 84
   at AndroidBinderator.Engine.BinderateAsync(BindingConfig config) in D:\a\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator\Engine.cs:line 54
   at Xamarin.AndroidBinderator.Tool.Program.Main(String[] args) in D:\a\1\s\Util\Xamarin.AndroidBinderator\Xamarin.AndroidBinderator.Tool\Program.cs:line 61
```

Filed with NuGet: https://github.com/NuGet/Home/issues/10342, however we need to work around this to be able to bind things today.  (This came up with the GPS/FB August 2020 bindings.)

If we see a Maven artifact without a period, we append a `.0` to it.