### PR TITLE
Minor updates to Google.Android.DataTransport TransportBackend*.

### DIFF
--- a/Android/Google.Android.DataTransport/build.cake
+++ b/Android/Google.Android.DataTransport/build.cake
@@ -10,16 +10,16 @@ var TARGET = Argument ("t", Argument ("target", "ci"));
 Dictionary<string, string> URLS_ARTIFACT_FILES= new Dictionary<string, string>()
 {
 	{
-		$"https://maven.google.com//com/google/android/datatransport/transport-api/2.2.0/transport-api-2.2.0.aar",
-		$"./externals/android/transport-api-2.2.0.aar"
+		$"https://maven.google.com//com/google/android/datatransport/transport-api/2.2.1/transport-api-2.2.1.aar",
+		$"./externals/android/transport-api-2.2.1.aar"
 	},
 	{
-		$"https://maven.google.com//com/google/android/datatransport/transport-backend-cct/2.3.0/transport-backend-cct-2.3.0.aar",
-		$"./externals/android/transport-backend-cct-2.3.0.aar"
+		$"https://maven.google.com//com/google/android/datatransport/transport-backend-cct/2.3.1/transport-backend-cct-2.3.1.aar",
+		$"./externals/android/transport-backend-cct-2.3.1.aar"
 	},
 	{
-		$"https://maven.google.com//com/google/android/datatransport/transport-runtime/2.2.3/transport-runtime-2.2.3.aar",
-		$"./externals/android/transport-runtime-2.2.3.aar"
+		$"https://maven.google.com//com/google/android/datatransport/transport-runtime/2.2.5/transport-runtime-2.2.5.aar",
+		$"./externals/android/transport-runtime-2.2.5.aar"
 	},
 };
 

--- a/Android/Google.Android.DataTransport/cgmanifest.json
+++ b/Android/Google.Android.DataTransport/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "transport-api",
           "GroupId": "com.google.android.datatransport",
-          "Version": "2.2.0",
+          "Version": "2.2.1",
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportApi"
         }
       },
@@ -15,7 +15,7 @@
         "Maven": {
           "ArtifactId": "transport-backend-cct",
           "GroupId": "com.google.android.datatransport",
-          "Version": "2.3.0",
+          "Version": "2.3.1",
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct"
         }
       },
@@ -24,7 +24,7 @@
         "Maven": {
           "ArtifactId": "transport-runtime",
           "GroupId": "com.google.android.datatransport",
-          "Version": "2.2.3",
+          "Version": "2.2.5",
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportRuntime"
         }
       }

--- a/Android/Google.Android.DataTransport/source/TransportApi/Xamarin.Google.Android.DataTransport.TransportApi.csproj
+++ b/Android/Google.Android.DataTransport/source/TransportApi/Xamarin.Google.Android.DataTransport.TransportApi.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Xamarin.Google.Android.DataTransport.TransportApi</PackageId>
-    <PackageVersion>2.2.0</PackageVersion>
+    <PackageVersion>2.2.1</PackageVersion>
     <Title>Xamarin.Google.Android.DataTransport.TransportApi</Title>
     <PackageDescription>Bindings for Google.Android.DataTransport.TransportApi package</PackageDescription>
     <Owners>Microsoft</Owners>

--- a/Android/Google.Android.DataTransport/source/TransportBackendCct/Xamarin.Google.Android.DataTransport.TransportBackendCct.csproj
+++ b/Android/Google.Android.DataTransport/source/TransportBackendCct/Xamarin.Google.Android.DataTransport.TransportBackendCct.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Xamarin.Google.Android.DataTransport.TransportBackendCct</PackageId>
-    <PackageVersion>2.3.0</PackageVersion>
+    <PackageVersion>2.3.1</PackageVersion>
     <Title>Xamarin.Google.Android.DataTransport.TransportBackendCct</Title>
     <PackageDescription>Bindings for Xamarin Google.Android.DataTransport.TransportBackendCct package</PackageDescription>
     <Owners>Microsoft</Owners>

--- a/Android/Google.Android.DataTransport/source/TransportRuntime/Xamarin.Google.Android.DataTransport.TransportRuntime.csproj
+++ b/Android/Google.Android.DataTransport/source/TransportRuntime/Xamarin.Google.Android.DataTransport.TransportRuntime.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Xamarin.Google.Android.DataTransport.TransportRuntime</PackageId>
-    <PackageVersion>2.2.3</PackageVersion>
+    <PackageVersion>2.2.5</PackageVersion>
     <Title>Xamarin.Google.Android.DataTransport.TransportRuntime</Title>
     <PackageDescription>Bindings for Google.Android.DataTransport.TransportRuntime package</PackageDescription>
     <Owners>Microsoft</Owners>


### PR DESCRIPTION
Version bumps needed for GPS/FB August 2020 updates.

- com.google.android.datatransport.transport-api (2.2.0 -> 2.2.1)
- com.google.android.datatransport.transport-backend-cct (2.3.0 -> 2.3.1)
- com.google.android.datatransport.transport-runtime (2.2.3 -> 2.2.5)