### PR TITLE
Use the microbuild version of signing

### DIFF
--- a/Android/Kotlin/source/Project.cshtml
+++ b/Android/Kotlin/source/Project.cshtml
@@ -60,6 +60,7 @@
 
   <ItemGroup>
     <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework)" />
+    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\$(TargetFramework)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SignList.xml
+++ b/SignList.xml
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <!-- <FirstParty Include="Library.dll" /> -->
+    <!-- <FirstParty Include="Library.jar" /> -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <ThirdParty Include="Newtonsoft.Json.dll" /> -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <Skip Include="System.*.dll" /> -->
+  </ItemGroup>
+
+</Project>

--- a/SignList.xml
+++ b/SignList.xml
@@ -1,8 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <!-- <FirstParty Include="Library.dll" /> -->
-    <!-- <FirstParty Include="Library.jar" /> -->
+    <FirstParty Include="Xamarin.*.dll" />
+
+    <!-- Kotlin -->
+    <FirstParty Include="org.jetbrains.*.jar" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
+      ref: refs/heads/main
     - repository: components
       type: github
       name: xamarin/XamarinComponents
@@ -57,6 +58,3 @@ jobs:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
-        signTags: true
-        signMain: true
-        realSign: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
         - 'xamarin.androidbinderator.tool': '0.4.2'
         - 'xamarin.androidx.migration.tool': '1.0.7.1'
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    - template: sign-artifacts/jobs/v1.yml@internal-templates
+    - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
         signTags: true


### PR DESCRIPTION
We're trying to remove all dependencies on the existing code-sign instance, in particular the `sign-from-vsts` job.

This is the last place that uses the pipeline, and I'm curious if we could just switch over to microbuild here instead.