### PR TITLE
[EN] [iOS] Add support for iOS 12.5

### DIFF
--- a/iOS/ExposureNotification/source/ApiDefinition.cs
+++ b/iOS/ExposureNotification/source/ApiDefinition.cs
@@ -357,6 +357,11 @@ namespace ExposureNotifications {
 	delegate void ENGetExposureWindowsHandler ([NullAllowed] ENExposureWindow [] exposureWindows, [NullAllowed] NSError error);
 	delegate void ENGetUserTraveledHandler (bool traveled, NSError error);
 
+	[Introduced (PlatformName.iOS, 12, 5)]
+	public enum ENActivityFlags : uint {
+		ENActivityFlagsPeriodicRun = 1U << 2
+	}
+
 	[Introduced (PlatformName.iOS, 13, 5)]
 	[BaseType (typeof (NSObject))]
 	interface ENManager {
@@ -369,6 +374,9 @@ namespace ExposureNotifications {
 
 		[NullAllowed, Export("invalidationHandler", ArgumentSemantic.Copy)]
 		Action InvalidationHandler { get; set; }
+
+		[NullAllowed, Export ("activityHandler", ArgumentSemantic.Copy)]
+		Action<ENActivityFlags> LaunchActivityHandler { get; set; }
 
 		[Async]
 		[Export ("activateWithCompletionHandler:")]

--- a/iOS/ExposureNotification/source/ApiDefinition.cs
+++ b/iOS/ExposureNotification/source/ApiDefinition.cs
@@ -357,11 +357,6 @@ namespace ExposureNotifications {
 	delegate void ENGetExposureWindowsHandler ([NullAllowed] ENExposureWindow [] exposureWindows, [NullAllowed] NSError error);
 	delegate void ENGetUserTraveledHandler (bool traveled, NSError error);
 
-	[Introduced (PlatformName.iOS, 12, 5)]
-	public enum ENActivityFlags : uint {
-		ENActivityFlagsPeriodicRun = 1U << 2
-	}
-
 	[Introduced (PlatformName.iOS, 13, 5)]
 	[BaseType (typeof (NSObject))]
 	interface ENManager {
@@ -374,9 +369,6 @@ namespace ExposureNotifications {
 
 		[NullAllowed, Export("invalidationHandler", ArgumentSemantic.Copy)]
 		Action InvalidationHandler { get; set; }
-
-		[NullAllowed, Export ("activityHandler", ArgumentSemantic.Copy)]
-		Action<ENActivityFlags> LaunchActivityHandler { get; set; }
 
 		[Async]
 		[Export ("activateWithCompletionHandler:")]

--- a/iOS/ExposureNotification/source/ExposureNotification.csproj
+++ b/iOS/ExposureNotification/source/ExposureNotification.csproj
@@ -22,7 +22,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2128732</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.2.1</PackageVersion>
+    <PackageVersion>1.2.2</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iOS/ExposureNotification/source/ExposureNotification.csproj
+++ b/iOS/ExposureNotification/source/ExposureNotification.csproj
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
     <TargetFrameworks>Xamarin.iOS10</TargetFrameworks>
@@ -43,5 +42,4 @@
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" Condition=" '$(EnableDefaultCompileItems)' == 'true'" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/iOS/ExposureNotification/source/ExposureNotification.csproj
+++ b/iOS/ExposureNotification/source/ExposureNotification.csproj
@@ -22,7 +22,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2128732</PackageProjectUrl>
     <PackageLicenseFile>License.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.2.2</PackageVersion>
+    <PackageVersion>1.2.2-preview1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/iOS/ExposureNotification/source/Extensions.cs
+++ b/iOS/ExposureNotification/source/Extensions.cs
@@ -28,6 +28,7 @@ namespace ExposureNotifications {
 	}
 
 	[Introduced (PlatformName.iOS, 12, 5)]
+	[Flags]
 	public enum ENActivityFlags : uint {
 		PeriodicRun = 1U << 2
 	}

--- a/iOS/ExposureNotification/source/Extensions.cs
+++ b/iOS/ExposureNotification/source/Extensions.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
 
 namespace ExposureNotifications {
 
@@ -22,5 +25,42 @@ namespace ExposureNotifications {
 		public static byte Default { get; } = 1;
 		public static byte Min { get; } = byte.MinValue;
 		public static byte Max { get; } = 100;
+	}
+
+	[Introduced (PlatformName.iOS, 12, 5)]
+	public enum ENActivityFlags : uint {
+		ENActivityFlagsPeriodicRun = 1U << 2
+	}
+
+	public delegate void ENActivityHandler (ENActivityFlags activityFlags);
+
+	partial class ENManager {
+		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint = "_Block_copy")]
+		private static extern IntPtr _Block_copy (ref BlockLiteral block);
+
+		[DllImport ("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		private extern static void void_objc_msgSend_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);
+
+		private delegate void ENActivityHandlerCallbackDelegate (IntPtr block, ENActivityFlags activityFlags);
+
+		[MonoPInvokeCallback (typeof (ENActivityHandlerCallbackDelegate))]
+		private static unsafe void ENActivityHandlerCallback (IntPtr block, ENActivityFlags activityFlags)
+		{
+			var descriptor = (BlockLiteral*) block;
+			var del = (ENActivityHandler) (descriptor->Target);
+			del?.Invoke (activityFlags);
+		}
+
+		private static ENActivityHandlerCallbackDelegate ENActivityHandlerCallbackReference = ENActivityHandlerCallback;
+
+		public void SetLaunchActivityHandler (ENActivityHandler activityHandler)
+		{
+			var block = new BlockLiteral ();
+			block.SetupBlock (ENActivityHandlerCallbackReference, activityHandler);
+			var ptr = _Block_copy (ref block);
+
+			var key = new NSString ("activityHandler");
+			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle ("setValue:forKey:"), ptr, key.Handle);
+		}
 	}
 }

--- a/iOS/ExposureNotification/source/Extensions.cs
+++ b/iOS/ExposureNotification/source/Extensions.cs
@@ -27,7 +27,6 @@ namespace ExposureNotifications {
 		public static byte Max { get; } = 100;
 	}
 
-	[Introduced (PlatformName.iOS, 12, 5)]
 	[Flags]
 	public enum ENActivityFlags : uint {
 		PeriodicRun = 1U << 2
@@ -56,9 +55,12 @@ namespace ExposureNotifications {
 
 		public void SetLaunchActivityHandler (ENActivityHandler activityHandler)
 		{
-			var block = new BlockLiteral ();
-			block.SetupBlock (ENActivityHandlerCallbackReference, activityHandler);
-			var ptr = _Block_copy (ref block);
+			var ptr = IntPtr.Zero;
+			if (activityHandler != null) {
+				var block = new BlockLiteral ();
+				block.SetupBlock (ENActivityHandlerCallbackReference, activityHandler);
+				ptr = _Block_copy (ref block);
+			}
 
 			var key = new NSString ("activityHandler");
 			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle ("setValue:forKey:"), ptr, key.Handle);

--- a/iOS/ExposureNotification/source/Extensions.cs
+++ b/iOS/ExposureNotification/source/Extensions.cs
@@ -29,7 +29,7 @@ namespace ExposureNotifications {
 
 	[Introduced (PlatformName.iOS, 12, 5)]
 	public enum ENActivityFlags : uint {
-		ENActivityFlagsPeriodicRun = 1U << 2
+		PeriodicRun = 1U << 2
 	}
 
 	public delegate void ENActivityHandler (ENActivityFlags activityFlags);

--- a/iOS/ExposureNotification/source/Extensions.cs
+++ b/iOS/ExposureNotification/source/Extensions.cs
@@ -55,15 +55,22 @@ namespace ExposureNotifications {
 
 		public void SetLaunchActivityHandler (ENActivityHandler activityHandler)
 		{
-			var ptr = IntPtr.Zero;
-			if (activityHandler != null) {
-				var block = new BlockLiteral ();
-				block.SetupBlock (ENActivityHandlerCallbackReference, activityHandler);
-				ptr = _Block_copy (ref block);
+			var key = new NSString ("activityHandler");
+			var sel = Selector.GetHandle ("setValue:forKey:");
+
+			// clear value
+			if (activityHandler == null) {
+				void_objc_msgSend_IntPtr_IntPtr (Handle, sel, IntPtr.Zero, key.Handle);
+				return;
 			}
 
-			var key = new NSString ("activityHandler");
-			void_objc_msgSend_IntPtr_IntPtr (this.Handle, Selector.GetHandle ("setValue:forKey:"), ptr, key.Handle);
+			// create block
+			var block = new BlockLiteral ();
+			block.SetupBlock (ENActivityHandlerCallbackReference, activityHandler);
+			var ptr = _Block_copy (ref block);
+
+			// assign
+			void_objc_msgSend_IntPtr_IntPtr (Handle, sel, ptr, key.Handle);
 		}
 	}
 }


### PR DESCRIPTION
Apple backported some features to the 12.5 update: https://developer.apple.com/documentation/exposurenotification/supporting_exposure_notifications_in_ios_12_5

Usage of this should really be a check for "if iOS 12.5, then set the `LaunchActivityHandler` property, otherwise register a background task. 

```csharp
private ENManager GetManager ()
{
    // the type is not available
    if (ObjCRuntime.Class.GetHandle ("ENManager") == IntPtr.Zero)
        return null;

    // create the manager
    var manager = new ENManager ();

    if (DeviceInfo.Version < new Version (13, 5)) { 
        // backwards compat
        manager.SetLaunchActivityHandler (activityFlags => {
            if (activityFlags.HasFlag(ENActivityFlags.PeriodicRun)) {
                // Your app now has 3.5 minutes to perform download and detection.
            }
        });
    } else {
        // schedule background task using BGTaskScheduler
    }

    // ...

    return manager;
}
```