### PR TITLE
[EN] [XPlat] Add support for iOS 12.5

### DIFF
--- a/XPlat/ExposureNotification/build.cake
+++ b/XPlat/ExposureNotification/build.cake
@@ -1,7 +1,6 @@
 var TARGET = Argument("t", Argument("target", "ci"));
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
-var NUGET_VERSION = "0.13.0-preview";
 
 Task("nuget")
 	.Does(() =>
@@ -11,7 +10,6 @@ Task("nuget")
 		.WithRestore()
 		.WithTarget("Build")
 		.WithTarget("Pack")
-		.WithProperty("PackageVersion", NUGET_VERSION)
 		.WithProperty("PackageOutputPath", MakeAbsolute(OUTPUT_PATH).FullPath));
 });
 

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -14,14 +14,40 @@ namespace Xamarin.ExposureNotifications
 {
 	public static partial class ExposureNotification
 	{
-		static ENManager manager;
+		// This is a special ID suffix which iOS treats a certain way
+		// we can basically request infinite background tasks
+		// and iOS will throttle it sensibly for us.
+		static readonly string backgroundTaskId = AppInfo.PackageName + ".exposure-notification";
 
+		static ENManager instance;
+		static bool isActivated;
+
+		// get a valid instance that may not be ready
+		static ENManager Instance
+		{
+			get
+			{
+				if (instance != null)
+					return instance;
+
+				if (ObjCRuntime.Class.GetHandle("ENManager") != null)
+					return instance ??= new ENManager();
+
+				return null;
+			}
+		}
+
+		// get the activated instance
 		static async Task<ENManager> GetManagerAsync()
 		{
-			if (manager == null)
+			EnsureSupported();
+
+			var manager = Instance;
+
+			if (!isActivated)
 			{
-				manager = new ENManager();
 				await manager.ActivateAsync();
+				isActivated = true;
 			}
 
 			return manager;
@@ -62,9 +88,9 @@ namespace Xamarin.ExposureNotifications
 			return nc;
 		}
 
-		static void PlatformInit()
+		static async void PlatformInit()
 		{
-			_ = ScheduleFetchAsync();
+			await ScheduleFetchAsync();
 		}
 
 		static async Task PlatformStart()
@@ -87,13 +113,55 @@ namespace Xamarin.ExposureNotifications
 
 		static Task PlatformScheduleFetch()
 		{
-			// This is a special ID suffix which iOS treats a certain way
-			// we can basically request infinite background tasks
-			// and iOS will throttle it sensibly for us.
-			var id = AppInfo.PackageName + ".exposure-notification";
+			if (!IsSupported)
+				return Task.CompletedTask;
 
+			if (DeviceInfo.Version < new Version(13, 5))
+				CreateLaunchActivityHandler();
+			else
+				CreateBackgroundTask();
+
+			return Task.CompletedTask;
+		}
+
+		static void CreateLaunchActivityHandler()
+		{
 			var isUpdating = false;
-			BGTaskScheduler.Shared.Register(id, null, task =>
+			Instance.SetLaunchActivityHandler(activityFlags =>
+			{
+				if (!activityFlags.HasFlag(ENActivityFlags.PeriodicRun))
+					return;
+
+				// Disallow concurrent exposure detection.
+				if (isUpdating)
+					return;
+				isUpdating = true;
+
+				// Run the actual task on a background thread
+				Task.Run(async () =>
+				{
+					try
+					{
+						await UpdateKeysFromServer();
+					}
+					catch (OperationCanceledException)
+					{
+						Console.WriteLine($"[Xamarin.ExposureNotifications] Launch activity handler took too long to complete.");
+					}
+					catch (Exception ex)
+					{
+						Console.WriteLine($"[Xamarin.ExposureNotifications] There was an error running the launch activity handler: {ex}");
+					}
+
+					isUpdating = false;
+				});
+			});
+		}
+
+		static void CreateBackgroundTask()
+		{
+			var isUpdating = false;
+			BGTaskScheduler.Shared.Register(backgroundTaskId, null, task =>
 			{
 				// Disallow concurrent exposure detection, because if allowed we might try to detect the same diagnosis keys more than once
 				if (isUpdating)
@@ -132,14 +200,12 @@ namespace Xamarin.ExposureNotifications
 
 			scheduleBgTask();
 
-			return Task.CompletedTask;
-
-			void scheduleBgTask()
+			static void scheduleBgTask()
 			{
 				if (ENManager.AuthorizationStatus != ENAuthorizationStatus.Authorized)
 					return;
 
-				var newBgTask = new BGProcessingTaskRequest(id);
+				var newBgTask = new BGProcessingTaskRequest(backgroundTaskId);
 				newBgTask.RequiresNetworkConnectivity = true;
 				try
 				{

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.ios.cs
@@ -116,7 +116,8 @@ namespace Xamarin.ExposureNotifications
 			if (!IsSupported)
 				return Task.CompletedTask;
 
-			if (DeviceInfo.Version < new Version(13, 5))
+			// BGTaskScheduler is only available from iOS 13.0
+			if (DeviceInfo.Version < new Version(13, 0))
 				CreateLaunchActivityHandler();
 			else
 				CreateBackgroundTask();

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.netstandard.cs
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.netstandard.cs
@@ -7,6 +7,8 @@ namespace Xamarin.ExposureNotifications
 {
 	public static partial class ExposureNotification
 	{
+		static object Instance => null;
+
 		static void PlatformInit()
 			=> throw new PlatformNotSupportedException();
 

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.shared.cs
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/ExposureNotification.shared.cs
@@ -18,6 +18,14 @@ namespace Xamarin.ExposureNotifications
 		public static bool OverridesNativeImplementation
 			=> ExposureNotification.nativeImplementation != null;
 
+		public static bool IsSupported => Instance != null;
+
+		internal static void EnsureSupported()
+		{
+			if (Instance == null)
+				throw new PlatformNotSupportedException("Exposure notifications are not supported on this device.");
+		}
+
 		internal static IExposureNotificationHandler Handler
 		{
 			get

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
@@ -11,9 +11,9 @@
 
 	<PropertyGroup>
 		<PackageId>Xamarin.ExposureNotification</PackageId>
-		<Summary>Cross Platform Exposure Notification for Xamarin</Summary>
-		<Title>Xamarin Exposure Notification</Title>
-		<Description>Cross Platform Exposure Notification for Xamarin</Description>
+		<Summary>Cross-Platform Exposure Notifications for Xamarin</Summary>
+		<Title>Xamarin Exposure Notifications</Title>
+		<Description>Cross-Platform Exposure Notifications for Xamarin</Description>
 		<PackageVersion>0.1.0-preview</PackageVersion>
 		<Authors>Microsoft</Authors>
 		<Owners>microsoft,Xamarin,XamarinNuGet</Owners>

--- a/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
+++ b/XPlat/ExposureNotification/source/Xamarin.ExposureNotification/Xamarin.ExposureNotification.csproj
@@ -14,7 +14,7 @@
 		<Summary>Cross-Platform Exposure Notifications for Xamarin</Summary>
 		<Title>Xamarin Exposure Notifications</Title>
 		<Description>Cross-Platform Exposure Notifications for Xamarin</Description>
-		<PackageVersion>0.1.0-preview</PackageVersion>
+		<PackageVersion>0.14.0-preview</PackageVersion>
 		<Authors>Microsoft</Authors>
 		<Owners>microsoft,Xamarin,XamarinNuGet</Owners>
 		<NeutralLanguage>en</NeutralLanguage>
@@ -31,7 +31,7 @@
 
 		<None Include="..\..\LICENSE.md" Pack="True" PackagePath="LICENSE.md" />
 
-		<PackageReference Include="Xamarin.Essentials" Version="1.5.3.1" />
+		<PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
@@ -55,7 +55,7 @@
 		<Compile Include="*.ios.*.cs" />
 
 		<PackageReference Include="System.IO.Compression" Version="4.3.0" />
-		<PackageReference Include="Xamarin.iOS.ExposureNotification" Version="1.0.0" />
+		<PackageReference Include="Xamarin.iOS.ExposureNotification" Version="1.2.2-preview1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
**iOS 12.5 Support**

This PR adds the support for iOS 12.5 notifications. To enable this platform, no actual code needs to change. This is done by leveraging the `ScheduleFetch` method to determine which task registration method to use - either BGTask or the new way. This method is actually called by `Init`, so it happens early on.

**IsSupported**

On platforms that do not support EN, such as iOS 10 or iOS 13.2, then it will now throw. To detect these scenarios, there is a new property `IsSupported` that can be used to display messages to the user. If it is `true`, then it does not guarantee that everything is ready to be used, but if it is `false`, then it is guaranteed that EN _cannot_ be used. 

The reason for this is that it will typically return `true`, and then if the user denies permissions or (on Android) GPS is out of date, or on iOS there is some extra criteria. These will be handled by the normal exceptions (unchanged). When this returns false, it means that there is _no_ EN support at all. Either no APIs or GPS explicitly indicated that there is no EN support on the device. 

If there is a case where this property is returning `true` and it can be pre-determined that it should return false, feel free to open an issue and I will try make sure we handle those extra cases.