### PR TITLE
Adopt azure-notificationhubs-android version 1.1.4

### DIFF
--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -28,7 +28,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864958</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=864960</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.1.3</PackageVersion>
+    <PackageVersion>1.1.4</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -4,8 +4,8 @@ var IOS_VERSION = "3.1.1";
 var IOS_NUGET_VERSION = "3.1.1";
 var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging-SDK-Apple-{IOS_VERSION}.zip";
 
-var ANDROID_VERSION = "1.1.3";
-var ANDROID_NUGET_VERSION = "1.1.3";
+var ANDROID_VERSION = "1.1.4";
+var ANDROID_NUGET_VERSION = "1.1.4";
 var ANDROID_URL = $"https://dl.bintray.com/microsoftazuremobile/SDK/com/microsoft/azure/notification-hubs-android-sdk/{ANDROID_VERSION}/notification-hubs-android-sdk-{ANDROID_VERSION}.aar";
 
 Task("libs-ios")


### PR DESCRIPTION
Adopting new version of the ANH android library, which fixes a critical bug for customer adopting this library.