### PR TITLE
[azdo] make dotnet parameter optional

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -106,11 +106,13 @@ jobs:
         inputs:
           version: ${{ parameters.dotnet }}
           performMultiLevelLookup: true
+        condition: ne('${{ parameters.dotnet }}', '')
       - pwsh: |
           dotnet tool install -g api-tools --version ${{ parameters.apiTools }}
           dotnet tool install -g cake.tool --version ${{ parameters.cake }}
           dotnet tool install -g Microsoft.DotNet.XHarness.CLI --version ${{ parameters.xharness }} --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
         displayName: 'Install required .NET Core global tools'
+        condition: ne('${{ parameters.dotnet }}', '')
       - ${{ each tool in parameters.tools }}:
         - ${{ each pair in tool }}:
           - pwsh: dotnet tool install -g ${{ pair.key }} --version ${{ pair.value }}


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/247
Context: https://github.com/xamarin/Xamarin.Legacy.Sdk

I'm testing out if we can multi-target the AndroidX libraries for `MonoAndroid90;net6.0-android`.

Unfortunately the build fails because:

1. The `UseDotNet@2` yaml task can't install .NET
   6.0.100-alpha.1.21064.27. We have to use the `dotnet-install`
   script to install it ourselves.

2. `dotnet tool` commands won't work, if there is a `global.json` file
   targeting `6.0.100-alpha.1.21064.27`.

I think for now, we should make it so callers can set `dotnet: ''` and
skip many of these steps. Callers can also leave the `tools: []`
parameter blank.

If a build needs to install .NET 6 and other .NET global tools, I
think it will be able to be done in `preBuildSteps` after these
changes.