### PR TITLE
[azdo] add initSteps for installing .NET 6

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -4,6 +4,7 @@ parameters:
   displayName: 'Build'                                      # the human name of the job
   timeoutInMinutes: 60                                      # the timeout in minutes
   dependsOn: []                                             # any jobs this job depends on
+  initSteps: []                                             # any steps to run before .NET global tools are installed
   preBuildSteps: []                                         # any steps that need to run just before the main compilation starts
   postBuildSteps: []                                        # any steps that need to run just after the main compilation ends
   masterBranchName: 'master'                                # the "master" branch that should be used - can be something other than "master"
@@ -107,12 +108,13 @@ jobs:
           version: ${{ parameters.dotnet }}
           performMultiLevelLookup: true
         condition: ne('${{ parameters.dotnet }}', '')
+      # custom init steps
+      - ${{ parameters.initSteps }}
       - pwsh: |
           dotnet tool install -g api-tools --version ${{ parameters.apiTools }}
           dotnet tool install -g cake.tool --version ${{ parameters.cake }}
           dotnet tool install -g Microsoft.DotNet.XHarness.CLI --version ${{ parameters.xharness }} --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
         displayName: 'Install required .NET Core global tools'
-        condition: ne('${{ parameters.dotnet }}', '')
       - ${{ each tool in parameters.tools }}:
         - ${{ each pair in tool }}:
           - pwsh: dotnet tool install -g ${{ pair.key }} --version ${{ pair.value }}


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/247

To improve upon the changes in abda7267, we could add a new
`initSteps` to install .NET 6.

Previously, if we could only install .NET 6 during `preBuildSteps`,
then the `dotnet tool` commands would fail:

    - pwsh: |
        dotnet tool install -g api-tools --version ${{ parameters.apiTools }}
    ...
    displayName: 'Install required .NET Core global tools'

Because .NET 6 is defined in `global.json`, you would get an error
saying there was no .NET 6 installed.

If we add a new `initSteps`, we could do something like:

    initSteps:
      - pwsh: |
          $ProgressPreference = 'SilentlyContinue'
          Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
          & .\dotnet-install.ps1 -Version $(DotNet6Version) -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
    tools:
      - 'xamarin.androidbinderator.tool': '0.4.2'
      - 'xamarin.androidx.migration.tool': '1.0.7.1'

Then the `dotnet tool` commands will succeed.