### PR TITLE
Upgrade Azure Notification Hub Firebase Version

### DIFF
--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -28,7 +28,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864958</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=864960</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>1.1.4</PackageVersion>
+    <PackageVersion>1.1.4.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
     <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.2.2" />
     <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.2" />
-    <PackageReference Include="Xamarin.Firebase.Messaging" Version="120.1.7" />
+    <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.0.1" />
     <PackageReference Include="Xamarin.Android.Volley" Version="1.1.1.1" />
   </ItemGroup>
 

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -44,8 +44,8 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
-    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.2.2" />
-    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.2" />
+    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.3" />
+    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.5" />
     <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.0.1" />
     <PackageReference Include="Xamarin.Android.Volley" Version="1.1.1.1" />
   </ItemGroup>

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -44,8 +44,6 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
-    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.3" />
-    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.5" />
     <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.0.1" />
     <PackageReference Include="Xamarin.Android.Volley" Version="1.1.1.1" />
   </ItemGroup>

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -42,6 +42,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.3" />
+    <PackageReference Include="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.5" />
     <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.0.1" />
     <PackageReference Include="Xamarin.Android.Volley" Version="1.1.1.1" />
   </ItemGroup>

--- a/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
+++ b/XPlat/AzureMessaging/Android/source/Xamarin.Azure.NotificationHubs.Android.csproj
@@ -42,8 +42,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.5" />
-    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
     <PackageReference Include="Xamarin.Firebase.Messaging" Version="121.0.1" />
     <PackageReference Include="Xamarin.Android.Volley" Version="1.1.1.1" />
   </ItemGroup>

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -5,7 +5,7 @@ var IOS_NUGET_VERSION = "3.1.1";
 var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/download/{IOS_VERSION}/WindowsAzureMessaging-SDK-Apple-{IOS_VERSION}.zip";
 
 var ANDROID_VERSION = "1.1.4";
-var ANDROID_NUGET_VERSION = "1.1.4";
+var ANDROID_NUGET_VERSION = "1.1.4.1";
 var ANDROID_URL = $"https://dl.bintray.com/microsoftazuremobile/SDK/com/microsoft/azure/notification-hubs-android-sdk/{ANDROID_VERSION}/notification-hubs-android-sdk-{ANDROID_VERSION}.aar";
 
 Task("libs-ios")


### PR DESCRIPTION
`FirebaseMessaging` was introduced in [major version 21](https://firebase.google.com/support/release-notes/android#iid_v21-0-0). We must update the Xamarin bindings to target the most recent version.