### PR TITLE
[Glide] Add the missing methods/types

### DIFF
--- a/Android/Glide/build.cake
+++ b/Android/Glide/build.cake
@@ -3,24 +3,26 @@
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
+var NUGET_PATCH = ".1";
+
 var GLIDE_VERSION = "4.11.0";
-var GLIDE_NUGET_VERSION = GLIDE_VERSION;
+var GLIDE_NUGET_VERSION = GLIDE_VERSION + NUGET_PATCH;
 var GLIDE_URL = $"https://repo1.maven.org/maven2/com/github/bumptech/glide/glide/{GLIDE_VERSION}/glide-{GLIDE_VERSION}.aar";
 
 var GIFDECODER_VERSION = GLIDE_VERSION;
-var GIFDECODER_NUGET_VERSION = GIFDECODER_VERSION;
+var GIFDECODER_NUGET_VERSION = GIFDECODER_VERSION + NUGET_PATCH;
 var GIFDECODER_URL = $"https://repo1.maven.org/maven2/com/github/bumptech/glide/gifdecoder/{GIFDECODER_VERSION}/gifdecoder-{GIFDECODER_VERSION}.aar";
 
 var DISKLRUCACHE_VERSION = GLIDE_VERSION;
-var DISKLRUCACHE_NUGET_VERSION = DISKLRUCACHE_VERSION;
+var DISKLRUCACHE_NUGET_VERSION = DISKLRUCACHE_VERSION + NUGET_PATCH;
 var DISKLRUCACHE_URL = $"https://repo1.maven.org/maven2/com/github/bumptech/glide/disklrucache/{DISKLRUCACHE_VERSION}/disklrucache-{DISKLRUCACHE_VERSION}.jar";
 
 var RECYCLERVIEW_VERSION = GLIDE_VERSION;
-var RECYCLERVIEW_NUGET_VERSION = RECYCLERVIEW_VERSION;
+var RECYCLERVIEW_NUGET_VERSION = RECYCLERVIEW_VERSION + NUGET_PATCH;
 var RECYCLERVIEW_URL = $"https://repo1.maven.org/maven2/com/github/bumptech/glide/recyclerview-integration/{RECYCLERVIEW_VERSION}/recyclerview-integration-{RECYCLERVIEW_VERSION}.aar";
 
 Task ("externals")
-	.WithCriteria (!FileExists ("./externals/guava.jar"))
+	.WithCriteria (!FileExists ("./externals/glide.aar"))
 	.Does (() =>
 {
 	if (!DirectoryExists ("./externals/"))

--- a/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0</PackageVersion>
+    <PackageVersion>4.11.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0</PackageVersion>
+    <PackageVersion>4.11.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0</PackageVersion>
+    <PackageVersion>4.11.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide/Transforms/Metadata.xml
+++ b/Android/Glide/source/Xamarin.Android.Glide/Transforms/Metadata.xml
@@ -90,6 +90,19 @@
   <attr path="/api/package[@name='com.bumptech.glide.module']/interface[@name='AppliesOptions']" name="visibility">public</attr>
   <attr path="/api/package[@name='com.bumptech.glide.module']/interface[@name='RegistersComponents']" name="visibility">public</attr>
 
+  <add-node path="/api/package[@name='com.bumptech.glide']/class[@name='GlideBuilder']">
+    <method abstract="false" deprecated="not deprecated" final="false" name="build" native="false" return="com.bumptech.glide.Glide" return-not-null="true"  static="false" synchronized="false" visibility="public">
+      <parameter name="context" type="android.content.Context" not-null="true" />
+    </method>
+  </add-node>
+
+  <attr path="/api/package[@name='com.bumptech.glide']/class[@name='GeneratedAppGlideModule']" name="visibility">public</attr>
+  <add-node path="/api/package[@name='com.bumptech.glide']/class[@name='GeneratedAppGlideModule']">
+    <constructor deprecated="not deprecated" final="false" name="GeneratedAppGlideModule" static="false" type="com.bumptech.glide.GeneratedAppGlideModule" synthetic="false" visibility="public" />
+    <method abstract="true" deprecated="not deprecated" final="false" name="getExcludedModuleClasses" native="false" return="java.util.Set&lt;java.lang.Class&gt;" return-not-null="true" static="false" synchronized="false" visibility="public" />
+    <method abstract="false" deprecated="not deprecated" final="false" name="getRequestManagerFactory" native="false" return="com.bumptech.glide.manager.RequestManagerRetriever.RequestManagerFactory" static="false" synchronized="false" visibility="public" />
+  </add-node>
+
   <add-node path="/api/package[@name='com.bumptech.glide.load.model.stream']/class[@name='BaseGlideUrlLoader']">
     <method abstract="true" deprecated="not deprecated" final="false" name="handles" native="false" return="boolean" static="false" synchronized="false" visibility="public">
       <parameter name="model" type="Model" />

--- a/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0</PackageVersion>
+    <PackageVersion>4.11.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A few things are needed if custom modules are going to be used. There are "private" in the sense of the word because they are only used by generated code. Since we are not using gradle runners, we still want them and we will just do it manually.