### PR TITLE
removed bintray urls

### DIFF
--- a/Android/AndroidThings/build.cake
+++ b/Android/AndroidThings/build.cake
@@ -1,6 +1,6 @@
 #load "../../common.cake"
 
-var TARGET = Argument ("t", Argument ("target", "Default"));
+var TARGET = Argument ("t", Argument ("target", "ci"));
 
 var NUGET_VERSION = "1.0.0.1";
 

--- a/Android/AndroidThings/build.cake
+++ b/Android/AndroidThings/build.cake
@@ -69,7 +69,10 @@ Task("nuget")
 });
 
 Task("samples");
+	.IsDependentOn("nuget");
 Task("component");
+Task("ci");
+	.IsDependentOn("samples");
 
 Task ("externals")
 	.Does (() => 

--- a/Android/AndroidThings/build.cake
+++ b/Android/AndroidThings/build.cake
@@ -5,8 +5,8 @@ var TARGET = Argument ("t", Argument ("target", "Default"));
 var NUGET_VERSION = "1.0.0.1";
 
 var JAR_VERSION = "1.0";
-var JAR_URL = string.Format ("https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fandroidthings%2F{0}%2Fandroidthings-{0}.jar", JAR_VERSION);
-var DOCS_URL = string.Format ("https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fandroidthings%2F{0}%2Fandroidthings-{0}-javadoc.jar", JAR_VERSION);
+var JAR_URL = $"https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fandroidthings%2F{JAR_VERSION}%2Fandroidthings-{JAR_VERSION}.jar";
+var DOCS_URL = $"https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fandroidthings%2F{JAR_VERSION}%2Fandroidthings-{JAR_VERSION}-javadoc.jar";
 
 var CONTRIB_URL = "https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fcontrib%2Fdriver-{0}%2F{1}%2Fdriver-{0}-{1}.aar";
 var CONTRIB_SRC_URL = "https://bintray.com/google/androidthings/download_file?file_path=com%2Fgoogle%2Fandroid%2Fthings%2Fcontrib%2Fdriver-{0}%2F{1}%2Fdriver-{0}-{1}-sources.jar";

--- a/Android/AnimatedCircleLoadingView/build.cake
+++ b/Android/AnimatedCircleLoadingView/build.cake
@@ -4,7 +4,7 @@
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var AAR_VERSION = "1.1.5";
-var AAR_URL = string.Format ("https://bintray.com/artifact/download/jlmd/maven/com/github/jlmd/AnimatedCircleLoadingView/{0}/AnimatedCircleLoadingView-{0}.aar", AAR_VERSION);
+var AAR_URL = $"https://bintray.com/artifact/download/jlmd/maven/com/github/jlmd/AnimatedCircleLoadingView/{AAR_VERSION}/AnimatedCircleLoadingView-{AAR_VERSION}.aar";
 var AAR_DEST = "./externals/AnimatedCircleLoadingView.aar";
 
 var buildSpec = new BuildSpec () {

--- a/Android/BetterPickers/build.cake
+++ b/Android/BetterPickers/build.cake
@@ -4,7 +4,7 @@
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var LIB_VERSION = "1.6.0";
-var AAR_URL = string.Format ("http://search.maven.org/remotecontent?filepath=com/doomonafireball/betterpickers/library/{0}/library-{0}.aar", LIB_VERSION);
+var AAR_URL = $"http://search.maven.org/remotecontent?filepath=com/doomonafireball/betterpickers/library/{LIB_VERSION}/library-{LIB_VERSION}.aar";
 
 var ASB_LIB_VERSION = "1.4.0";
 var ASB_AAR_URL = string.Format ("https://bintray.com/artifact/download/bod/JRAF/org/jraf/android-switch-backport/{0}/android-switch-backport-{0}.aar", ASB_LIB_VERSION);

--- a/Android/FirebaseJobDispatcher/build.cake
+++ b/Android/FirebaseJobDispatcher/build.cake
@@ -5,7 +5,7 @@ var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var ANDROID_VERSION = "0.8.5";
 var ANDROID_NUGET_VERSION = "0.8.5";
-var ANDROID_URL = string.Format ("https://jcenter.bintray.com/com/firebase/firebase-jobdispatcher/{0}/firebase-jobdispatcher-{0}.aar", ANDROID_VERSION);
+var ANDROID_URL = $"https://jcenter.bintray.com/com/firebase/firebase-jobdispatcher/{ANDROID_VERSION}/firebase-jobdispatcher-{ANDROID_VERSION}.aar";
 var ANDROID_FILE = "firebase-dispatcher.aar";
 
 var buildSpec = new BuildSpec () {

--- a/Android/RecyclerViewAnimators/build.cake
+++ b/Android/RecyclerViewAnimators/build.cake
@@ -4,7 +4,7 @@
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var JAR_VERSION = "2.1.0";
-var JAR_URL = string.Format ("https://bintray.com/artifact/download/wasabeef/maven/jp/wasabeef/recyclerview-animators/{0}/recyclerview-animators-{0}.aar", JAR_VERSION);
+var JAR_URL = $"https://repo1.maven.org/maven2/jp/wasabeef/recyclerview-animators/{JAR_VERSION}/recyclerview-animators-{JAR_VERSION}.aar";
 var JAR_DEST = "./externals/RecyclerViewAnimators.aar";
 
 var buildSpec = new BuildSpec () {

--- a/Android/SortableTableView/build.cake
+++ b/Android/SortableTableView/build.cake
@@ -4,7 +4,7 @@
 var TARGET = Argument ("t", Argument ("target", "Default"));
 
 var AAR_VERSION = "2.8.0";
-var AAR_URL = string.Format ("https://bintray.com/artifact/download/ischwarz/maven/de/codecrafters/tableview/tableview/{0}/tableview-{0}.aar", AAR_VERSION);
+var AAR_URL = $"https://bintray.com/artifact/download/ischwarz/maven/de/codecrafters/tableview/tableview/{AAR_VERSION}/tableview-{AAR_VERSION}.aar";
 var AAR_FILE = "SortableTableView.aar";
 
 var buildSpec = new BuildSpec () {

--- a/XPlat/AzureMessaging/build.cake
+++ b/XPlat/AzureMessaging/build.cake
@@ -6,7 +6,7 @@ var IOS_URL = $"https://github.com/Azure/azure-notificationhubs-ios/releases/dow
 
 var ANDROID_VERSION = "1.1.4";
 var ANDROID_NUGET_VERSION = "1.1.4.1";
-var ANDROID_URL = $"https://dl.bintray.com/microsoftazuremobile/SDK/com/microsoft/azure/notification-hubs-android-sdk/{ANDROID_VERSION}/notification-hubs-android-sdk-{ANDROID_VERSION}.aar";
+var ANDROID_URL = $"https://repo1.maven.org/maven2/com/microsoft/azure/notification-hubs-android-sdk/{ANDROID_VERSION}/notification-hubs-android-sdk-{ANDROID_VERSION}.aar";
 
 Task("libs-ios")
 	.WithCriteria(IsRunningOnUnix())
@@ -182,10 +182,17 @@ Task ("clean")
 	.Does (() => 
 {
 	if (DirectoryExists ("./Android/externals"))
-		DeleteDirectory ("./Android/externals", true);
+		DeleteDirectory ("./Android/externals", new DeleteDirectorySettings {
+		Recursive = true,
+		Force = true
+	});
 
 	if (DirectoryExists ("./iOS/externals"))
-		DeleteDirectory ("./iOS/externals", true);
-});
+		DeleteDirectory ("./iOS/externals", new DeleteDirectorySettings {
+		Recursive = true,
+		Force = true
+	});
+}
+);
 
 RunTarget (TARGET);

--- a/XPlat/OpenId/build.cake
+++ b/XPlat/OpenId/build.cake
@@ -8,7 +8,7 @@ var ANDROID_NUGET_VERSION = "0.7.0";
 var IOS_VERSION = "0.92.0";
 var IOS_NUGET_VERSION = "0.92.0";
 
-var AAR_URL = string.Format ("https://bintray.com/openid/net.openid/download_file?file_path=net%2Fopenid%2Fappauth%2F{0}%2Fappauth-{0}.aar", ANDROID_VERSION);
+var AAR_URL = $"https://repo1.maven.org/maven2/net/openid/appauth/{ANDROID_VERSION}/appauth-{ANDROID_VERSION}.aar";
 
 var PODFILE = new List<string> {
 	"platform :ios, '8.0'",

--- a/XPlat/Shopify/Android/build.cake
+++ b/XPlat/Shopify/Android/build.cake
@@ -1,7 +1,7 @@
 #load "../../../common.cake"
 
 var VERSION = "1.2.4";
-var URL = string.Format ("https://bintray.com/shopify/shopify-android/download_file?file_path=com%2Fshopify%2Fmobilebuysdk%2Fbuy%2F{0}%2Fbuy-{0}.aar", VERSION);
+var URL = $"https://bintray.com/shopify/shopify-android/download_file?file_path=com%2Fshopify%2Fmobilebuysdk%2Fbuy%2F{VERSION}%2Fbuy-{VERSION}.aar";
 
 var TARGET = Argument ("t", Argument ("target", "Default"));
 


### PR DESCRIPTION
bintray/jcenter urls removed for bindings where it was possible (if the same or newer artifact exists on maven central)

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

https://blog.gradle.org/jcenter-shutdown

NOTE: some bindings will fail, because of the old and obsoleted cake scripts (`common.cake`)
