### PR TITLE
Binderator improvements metadata files and dependency reporting

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Program.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Program.cs
@@ -81,6 +81,7 @@ namespace Xamarin.AndroidBinderator.Tool
                     sb.AppendLine($"	{exc.ToString()}");
                     i++;
                 }
+                Trace.WriteLine(sb.ToString());
             }
         }
     }

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.4.5</PackageVersion>
+    <PackageVersion>0.4.6</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -29,6 +29,9 @@ namespace AndroidBinderator
 		[JsonProperty("downloadJavaDocJars")]
 		public bool DownloadJavaDocJars { get; set; } = true;
 
+		[JsonProperty("downloadMetadataFiles")]
+		public bool DownloadMetadataFiles { get; set; } = true;
+
 		[JsonProperty("downloadPoms")]
 		public bool DownloadPoms { get; set; } = true;
 

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.2.5</PackageVersion>
+        <PackageVersion>2.2.6</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>
@@ -23,7 +23,7 @@
 
     <ItemGroup>
         <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
-        <PackageReference Include="MavenNet" Version="2.1.2" />
+        <PackageReference Include="MavenNet" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Added 

* metadata downloads

* javadoc downloads

  * MavenNet javadoc support
  
    * PR https://github.com/Redth/MavenNet/pull/6

* formatted output for missing artifacts

  * summary (number of exceptions - missing artifacts)
  
  * details about missing artifacts with suggestion code snippet to be added to `config.json`
  
    ```
    Dependency errors : 1
    1
	    System.Exception: 
    No matching artifact config found for: 
			    com.google.firebase.firebase-appcheck-interop:16.0.0-beta01
    to satisfy dependency of: 
			    com.google.firebase.firebase-database:20.0.0
    
	    Please add following json snippet to config.json:
    
    
          {
            "groupId": "com.google.firebase",
            "artifactId": "firebase-appcheck-interop",
            "version": "16.0.0-beta01",
            "nugetVersion": "CHECK THIS",
            "nugetId": "CHECK THIS",
            "dependencyOnly": true/false
          }
    ```