### PR TITLE
[binderator] Optionally include 'runtime' dependencies in dependency tree.

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -56,6 +56,13 @@ namespace AndroidBinderator
 		[JsonProperty("additionalProjects")]
 		public List<string> AdditionalProjects { get; set; } = new List<string>();
 
+		/// True to consider 'Runtime' dependencies from a POM file, False to ignore them.
+		[JsonProperty("strictRuntimeDependencies")]
+		public bool StrictRuntimeDependencies { get; set; }
+
+		[JsonProperty("excludedRuntimeDependencies")]
+		public string ExcludedRuntimeDependencies { get; set; }
+
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 	}

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -46,5 +46,10 @@ namespace AndroidBinderator
 
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+		[JsonProperty("excludedRuntimeDependencies")]
+		public string ExcludedRuntimeDependencies { get; set; }
+
+		public string GroupAndArtifactId => $"{GroupId}.{ArtifactId}";
 	}
 }

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using MavenNet.Models;
+
+namespace AndroidBinderator
+{
+	public static class Extensions
+	{
+		public static string OrEmpty (this string value) => value ?? string.Empty;
+
+		public static string GroupAndArtifactId (this Dependency dependency) => $"{dependency.GroupId}.{dependency.ArtifactId}";
+
+		public static bool IsCompileDependency (this Dependency dependency) => string.IsNullOrWhiteSpace (dependency.Scope) || dependency.Scope.ToLowerInvariant ().Equals ("compile");
+
+		public static bool IsRuntimeDependency (this Dependency dependency) => dependency != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
+	}
+}


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/pull/1101

Some `.pom` files list a dependency as scoped to `runtime`:

```xml
<dependency>
  <groupId>androidx.lifecycle</groupId>
  <artifactId>lifecycle-common</artifactId>
  <version>2.0.0</version>
  <scope>runtime</scope>
</dependency>
```

Today we ignore this dependency and do not add it to the NuGet dependency requirements because we only consider `<scope>compile</scope>`.  However this dependency is needed at runtime and thus users get an error when running their app like:
```
Java.Lang.NoClassDefFoundError: 'Failed resolution of: Landroidx/arch/core/executor/ArchTaskExecutor;
```

It looks like in the past we have manually added these dependencies: https://github.com/xamarin/AndroidX/blob/master/source/AndroidXProject.cshtml#L164-L185.

This is problematic because it requires a human to manually download and check POM files to see if any new `runtime` dependencies were added with each new package update. (And we may do dozens of updates a week.)

This PR adds a new `strictRuntimeDependencies` flag to the `config.json`, which defaults to `false`:

```json
"mavenRepositoryType": "Google",
"slnFile": "generated/AndroidX.sln",
"strictRuntimeDependencies": true,
...
```

When enabled, `runtime` POM dependencies are treated as `compile` dependencies and must be fulfilled.

However, there may be cases when it is not desirable to add a specific `runtime` dependency to a package, so there are also mechanisms to opt out.

At the artifact level, a comma delimited list of `runtime` dependencies to ignore can be provided to the `excludedRuntimeDependencies` element:

```json
{
  "groupId": "androidx.security",
  "artifactId": "security-crypto",
  "version": "1.0.0",
  "nugetVersion": "1.0.0",
  "nugetId": "Xamarin.AndroidX.Security.SecurityCrypto",
  "dependencyOnly": false,
  "excludedRuntimeDependencies": "com.google.crypto.tink.tink-android,com.google.auto.value.auto-value-annotations"
}
```

This can also been done at the config file level:

```json
"mavenRepositoryType": "Google",
"slnFile": "generated/AndroidX.sln",
"strictRuntimeDependencies": true,
"excludedRuntimeDependencies": "com.google.crypto.tink.tink-android,com.google.auto.value.auto-value-annotations"
```

Additionally this moves the dependency exception code out of the inner loop, so it can report errors for the entire file instead of only a single artifact.