### PR TITLE
[Mono.Options] Include symbol files in .nupkg

### DIFF
--- a/XPlat/Mono.Options/build.cake
+++ b/XPlat/Mono.Options/build.cake
@@ -2,12 +2,12 @@
 
 var TARGET = Argument("t", Argument("target", "ci"));
 
-var MONO_TAG = "mono-6.6.0.162";
+var MONO_TAG = "mono-6.12.0.148";
 
 var ASSEMBLY_VERSION = "6.0.0.0";
-var ASSEMBLY_FILE_VERSION = "6.6.0.0";
-var ASSEMBLY_INFO_VERSION = "6.6.0.162";
-var NUGET_VERSION = "6.6.0.162";
+var ASSEMBLY_FILE_VERSION = "6.12.0.0";
+var ASSEMBLY_INFO_VERSION = "6.12.0.148";
+var NUGET_VERSION = "6.12.0.148";
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
 

--- a/XPlat/Mono.Options/build.cake
+++ b/XPlat/Mono.Options/build.cake
@@ -2,12 +2,12 @@
 
 var TARGET = Argument("t", Argument("target", "ci"));
 
-var MONO_TAG = "mono-6.6.0.161";
+var MONO_TAG = "mono-6.6.0.162";
 
 var ASSEMBLY_VERSION = "6.0.0.0";
 var ASSEMBLY_FILE_VERSION = "6.6.0.0";
-var ASSEMBLY_INFO_VERSION = "6.6.0.161";
-var NUGET_VERSION = "6.6.0.161";
+var ASSEMBLY_INFO_VERSION = "6.6.0.162";
+var NUGET_VERSION = "6.6.0.162";
 
 var OUTPUT_PATH = (DirectoryPath)"./output/";
 

--- a/XPlat/Mono.Options/source/Mono.Options/Mono.Options.csproj
+++ b/XPlat/Mono.Options/source/Mono.Options/Mono.Options.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net40-client;net40;netstandard1.3;netstandard2.0;portable-net45+win8+wpa81+wp8</TargetFrameworks>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/XPlat/Mono.Options/source/Mono.Options/Mono.Options.csproj
+++ b/XPlat/Mono.Options/source/Mono.Options/Mono.Options.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
 
   <PropertyGroup>
-    <TargetFrameworks>net40-client;net40;netstandard1.3;netstandard2.0;portable-net45+win8+wpa81+wp8</TargetFrameworks>
+    <TargetFrameworks>net40-client;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 


### PR DESCRIPTION
Adds .pdb files to the Mono.Options NuGet package, and bumps the
package version to 6.12.0.148.