### PR TITLE
[Kotlin] Ensure .targets file gets put in both /build and /buildTransitive.

### DIFF
--- a/Android/Kotlin/source/Project.cshtml
+++ b/Android/Kotlin/source/Project.cshtml
@@ -59,8 +59,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework)" />
-    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\$(TargetFramework)" />
+    <None Update="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\$(TargetFramework);buildTransitive\$(TargetFramework)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In https://github.com/xamarin/XamarinComponents/pull/1043, we started including the `.targets` file in the `/buildTransitive` folder of the NuGet.  Unfortunately because the `ItemGroup` uses `Update` instead of `Include` we ended up overwriting the original instruction to include it in `/build`.

So our packages have only been placing the `.targets` file in `/buildTransitive` and not `/build`.  This breaks users who are still using `packages.configs`.

From https://github.com/NuGet/Home/wiki/Allow-package--authors-to-define-build-assets-transitive-behavior:
> To construct a package which allows build assets to flow transitively, package author will need to put all these build assets in /buildTransitive as well as /build folder to make the package compatible with packages.config.

This fix puts the `.targets` back in both folders.

Results:
![image](https://user-images.githubusercontent.com/179295/130647890-87e70610-a109-40bf-adf2-28593dd17e0a.png)
