### PR TITLE
[Binderator] Allow multiple templates sets to be used.

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.4.7</PackageVersion>
+    <PackageVersion>0.4.8</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/BindingConfig.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace AndroidBinderator
@@ -65,6 +67,28 @@ namespace AndroidBinderator
 
 		[JsonProperty("metadata")]
 		public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+		[JsonProperty("templateSets")]
+		public List<TemplateSetModel> TemplateSets { get; set; } = new List<TemplateSetModel>();
+
+		public TemplateSetModel GetTemplateSet(string name)
+		{
+			// If an artifact doesn't specify a template set, first try using the original
+			// single template list if it exists.  If not, look for a template set called "default".
+			if (string.IsNullOrEmpty(name)) {
+				if (Templates.Any())
+					return new TemplateSetModel { Templates = Templates };
+
+				name = "default";
+			}
+
+			var set = TemplateSets.FirstOrDefault(s => s.Name == name);
+
+			if (set == null)
+				throw new ArgumentException($"Could not find requested template set '{name}'");
+
+			return set;
+		}
 	}
 
 	public class BindingConfigDebug

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Config/MavenArtifactConfig.cs
@@ -50,6 +50,9 @@ namespace AndroidBinderator
 		[JsonProperty("excludedRuntimeDependencies")]
 		public string ExcludedRuntimeDependencies { get; set; }
 
+		[JsonProperty("templateSet")]
+		public string TemplateSet { get; set; }
+
 		public string GroupAndArtifactId => $"{GroupId}.{ArtifactId}";
 	}
 }

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MavenNet;
+
+namespace AndroidBinderator
+{
+	public static class MavenFactory
+	{
+		static readonly Dictionary<string, MavenRepository> repositories = new Dictionary<string, MavenRepository>();
+
+		public static async Task Initialize(BindingConfig config)
+		{
+			var artifact_mavens = new List<(MavenRepository, MavenArtifactConfig)>();
+
+			foreach (var artifact in config.MavenArtifacts.Where(ma => !ma.DependencyOnly)) {
+				var (type, location) = GetMavenInfoForArtifact(config, artifact);
+				var repo = GetOrCreateRepository(type, location);
+
+				artifact_mavens.Add((repo, artifact));
+			}
+
+			foreach (var group in artifact_mavens.GroupBy(a => a.Item1))
+				await group.Key.Refresh(group.Select (g => g.Item2.GroupId).Distinct().ToArray());
+		}
+
+		public static MavenRepository GetMavenRepository(BindingConfig config, MavenArtifactConfig artifact)
+		{
+			var (type, location) = GetMavenInfoForArtifact(config, artifact);
+			var repo = GetOrCreateRepository(type, location);
+
+			return repo;
+		}
+
+		static (MavenRepoType type, string location) GetMavenInfoForArtifact(BindingConfig config, MavenArtifactConfig artifact)
+		{
+			var template = config.GetTemplateSet(artifact.TemplateSet);
+
+			if (template.MavenRepositoryType.HasValue)
+				return (template.MavenRepositoryType.Value, template.MavenRepositoryLocation);
+
+			return (config.MavenRepositoryType, config.MavenRepositoryLocation);
+		}
+
+		static MavenRepository GetOrCreateRepository(MavenRepoType type, string location)
+		{
+			var key = $"{type}|{location}";
+
+			if (repositories.TryGetValue(key, out MavenRepository repository))
+				return repository;
+
+			MavenRepository maven;
+
+			if (type == MavenRepoType.Directory)
+				maven = MavenRepository.FromDirectory(location);
+			else if (type == MavenRepoType.Url)
+				maven = MavenRepository.FromUrl(location);
+			else if (type == MavenRepoType.MavenCentral)
+				maven = MavenRepository.FromMavenCentral();
+			else
+				maven = MavenRepository.FromGoogle();
+
+			repositories.Add(key, maven);
+
+			return maven;
+		}
+	}
+}

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/MavenArtifactModel.cs
@@ -10,6 +10,7 @@ namespace AndroidBinderator
 		public string MavenArtifactPackaging { get; set; }
 		public string MavenArtifactMd5 { get; set; }
 		public string MavenArtifactSha256 { get; set; }
+		public MavenArtifactConfig MavenArtifactConfig { get; set; }
 
 		public string DownloadedArtifact { get; set; }
 		public string ProguardFile { get; set; }

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/NuGetDependencyModel.cs
@@ -9,6 +9,7 @@ namespace AndroidBinderator
 		public string NuGetPackageId { get; set; }
 		public string NuGetVersionBase { get; set; }
 		public string NuGetVersionSuffix { get; set; }
+		public MavenArtifactConfig MavenArtifactConfig { get; set; }
 
 		public string NuGetVersion =>
 			!IsProjectReference || string.IsNullOrWhiteSpace(NuGetVersionSuffix)

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Model/TemplateSetModel.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace AndroidBinderator
+{
+	public class TemplateSetModel
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+		[JsonProperty("mavenRepositoryType")]
+		public MavenRepoType? MavenRepositoryType { get; set; }
+
+		[JsonProperty("mavenRepositoryLocation")]
+		public string MavenRepositoryLocation { get; set; } = null;
+
+		[JsonProperty("templates")]
+		public List<TemplateConfig> Templates { get; set; } = new List<TemplateConfig> ();
+	}
+}

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.2.7</PackageVersion>
+        <PackageVersion>2.2.8</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>


### PR DESCRIPTION
Today we use binderator to build things like Kotlin, AndroidX, and GPS.  However they are all built in separate binderator configuration files, which means we must manually maintain dependencies between them using `dependencyOnly=true` entries.  It would be nice if we could build more of them together to cut down on manual work.

There are 2 main problems with this:
- Each group uses a different set of templates, and trying to make a set of uber-templates would be very painful.
- Each group may come from a different Maven. ie: AndroidX is in Google's Maven while Kotlin is in Maven Central.

This PR adds the concept of "template sets" which allow artifacts that use different templates and settings to co-exist in the same `config.json`.

A template set looks like this:
```json
"templateSets": [
  {
    "name": "kotlin",
    "mavenRepositoryType" : "MavenCentral",
    "templates" : [
      {
        "templateFile": "templates/kotlin/Project.cshtml",
        "outputFileRule" : "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
      },
      {
        "templateFile": "templates/kotlin/Targets.cshtml",
        "outputFileRule" : "generated/{groupid}.{artifactid}/{nugetid}.targets"
      }
    ]      
  },
  {
    "name": "androidx",
    "mavenRepositoryType" : "Google",
    "templates" : [
      {
        "templateFile": "templates/androidx/Project.cshtml",
        "outputFileRule" : "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
      },
      {
        "templateFile": "templates/androidx/Targets.cshtml",
        "outputFileRule" : "generated/{groupid}.{artifactid}/{nugetid}.targets"
      }
    ]      
  }        
]
```

An artifact can opt into a different template set with the `templateSet` option:
```json
{
  "templateSet": "kotlin",
  "groupId" : "org.jetbrains.kotlin",
  "artifactId" : "kotlin-stdlib",
  "version" : "1.5.21",
  "nugetVersion" : "1.5.21",
  "nugetId" : "Xamarin.Kotlin.StdLib"
},
```

If `templateSet` is not specified on an artifact, it first tries to get them from the root `templates` value.  If that is missing, it will use the template set named `default`.  If that doesn't exist an error will be thrown.

A template set may specify a custom `mavenRepositoryType` and `mavenRepositoryLocation`.  If it is not specified it will use the global one defined in the root json.

These fallback mechanisms ensure that binderator remains compatible with existing `config.json` files.