### PR TITLE
Update ARCore to 1.25

### DIFF
--- a/Android/ARCore/build.cake
+++ b/Android/ARCore/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.24.0";
+var NUGET_VERSION = "1.25.0";
 
-var AAR_VERSION = "1.24.0";
+var AAR_VERSION = "1.25.0";
 var AAR_URL = string.Format("https://dl.google.com/dl/android/maven2/com/google/ar/core/{0}/core-{0}.aar", AAR_VERSION);
 var OBJ_VERSION = "0.3.0";
 var OBJ_URL = string.Format("https://oss.sonatype.org/content/repositories/releases/de/javagl/obj/{0}/obj-{0}.jar", OBJ_VERSION);

--- a/Android/ARCore/cgmanifest.json
+++ b/Android/ARCore/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "core",
           "GroupId": "com.google.ar",
-          "Version": "1.24.0",
+          "Version": "1.25.0",
           "NuGetId": "Xamarin.Google.ARCore"
         }
       }

--- a/Android/ARCore/samples/HelloAR/HelloAR.csproj
+++ b/Android/ARCore/samples/HelloAR/HelloAR.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <ReleaseVersion>1.14.0</ReleaseVersion>
+    <ReleaseVersion>1.25.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/samples/JavaGL/JavaGL.csproj
+++ b/Android/ARCore/samples/JavaGL/JavaGL.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidClassParser>class-parse</AndroidClassParser>
-    <ReleaseVersion>1.14.0</ReleaseVersion>
+    <ReleaseVersion>1.25.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Android/ARCore/source/Google.ARCore.csproj
+++ b/Android/ARCore/source/Google.ARCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <ReleaseVersion>1.24.0</ReleaseVersion>
+    <ReleaseVersion>1.25.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>


### PR DESCRIPTION
Just the bump of ARCore version to 1.25

Newest version available right now is 1.26.
I'm willing to make another pull request to update to 1.26, but I'd like to have both 1.25 and 1.26 available on NuGet. That's why I created the pull request to update to 1.25 first