### PR TITLE
Glide 4.12.0 republishing 4.12.0 with monoandroid9.0 (GPS-FB-MLKit dependency)

### DIFF
--- a/Android/Glide/build.cake
+++ b/Android/Glide/build.cake
@@ -1,6 +1,6 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_PATCH = "";
+var NUGET_PATCH = ".1";
 
 var GLIDE_VERSION = "4.12.0";
 var GLIDE_NUGET_VERSION = GLIDE_VERSION + NUGET_PATCH;

--- a/Android/Glide/cgmanifest.json
+++ b/Android/Glide/cgmanifest.json
@@ -6,7 +6,7 @@
           "Maven": {
             "ArtifactId": "glide",
             "GroupId": "com.github.bumptech.glide",
-            "Version": "4.11.0"
+            "Version": "4.12.0"
           }
         }
       },
@@ -16,7 +16,7 @@
           "Maven": {
             "ArtifactId": "gifdecoder",
             "GroupId": "com.github.bumptech.glide",
-            "Version": "4.11.0"
+            "Version": "4.12.0"
           }
         }
       },
@@ -26,7 +26,7 @@
           "Maven": {
             "ArtifactId": "disklrucache",
             "GroupId": "com.github.bumptech.glide",
-            "Version": "4.11.0"
+            "Version": "4.12.0"
           }
         }
       },
@@ -36,7 +36,7 @@
           "Maven": {
             "ArtifactId": "recyclerview-integration",
             "GroupId": "com.github.bumptech.glide",
-            "Version": "4.11.0"
+            "Version": "4.12.0"
           }
         }
       }

--- a/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid10.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;MonoAndroid10.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Android.Glide.DiskLruCache</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.DiskLruCache/Xamarin.Android.Glide.DiskLruCache.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0.2</PackageVersion>
+    <PackageVersion>4.12.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid10.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;MonoAndroid10.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Android.Glide.GifDecoder</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.GifDecoder/Xamarin.Android.Glide.GifDecoder.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0.2</PackageVersion>
+    <PackageVersion>4.12.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid10.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;MonoAndroid10.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Android.Glide.RecyclerViewIntegration</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide.RecyclerViewIntegration/Xamarin.Android.Glide.RecyclerViewIntegration.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0.2</PackageVersion>
+    <PackageVersion>4.12.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid10.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid9.0;MonoAndroid10.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Android.Glide</AssemblyName>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
+++ b/Android/Glide/source/Xamarin.Android.Glide/Xamarin.Android.Glide.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=864954</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865026</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>4.11.0.2</PackageVersion>
+    <PackageVersion>4.12.0.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Glide 4.12 republishing 4.12.0 with monoandroid9.0 (GPS-FB-MLKit dependency)

mutlitargeting + version bumps