### PR TITLE
[binderator] Fix for POM versions that use properties.

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.4.9</PackageVersion>
+    <PackageVersion>0.5.0</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/MavenFactory.cs
@@ -22,8 +22,17 @@ namespace AndroidBinderator
 				artifact_mavens.Add((repo, artifact));
 			}
 
-			foreach (var group in artifact_mavens.GroupBy(a => a.Item1))
-				await group.Key.Refresh(group.Select (g => g.Item2.GroupId).Distinct().ToArray());
+			foreach (var maven_group in artifact_mavens.GroupBy(a => a.Item1)) {
+				var maven = maven_group.Key;
+				var artifacts = maven_group.Select(a => a.Item2);
+
+				foreach (var artifact_group in artifacts.GroupBy(a => a.GroupId)) {
+					var gid = artifact_group.Key;
+					var artifact_ids = artifact_group.Select(a => a.ArtifactId).ToArray();
+
+					await maven.Populate(gid, artifact_ids);
+				}
+			}
 		}
 
 		public static MavenRepository GetMavenRepository(BindingConfig config, MavenArtifactConfig artifact)

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.2.9</PackageVersion>
+        <PackageVersion>2.3.0</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>
@@ -23,7 +23,7 @@
 
     <ItemGroup>
         <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
-        <PackageReference Include="MavenNet" Version="2.2.12" />
+        <PackageReference Include="MavenNet" Version="2.2.13" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Trying to bind `Tink` contains the dependency version `${gson.version}`.  In order to get the actual version number we need to handle POM properties:

```xml
<properties>
  <java.version>1.8</java.version>
  <gson.version>2.8.6</gson.version>
</properties>
<dependencies>
  <dependency>
    <groupId>com.google.code.gson</groupId>
    <artifactId>gson</artifactId>
    <version>${gson.version}</version>
  </dependency>
</dependencies>
```

Additionally, update to MavenNet 2.2.13 and use the new `Populate` method to get around this issue that is causing AndroidX CI to fail: https://github.com/Redth/MavenNet/pull/9.