### PR TITLE
[build.yml] Allow consumers to specify pools other than Azure Pipelines.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -17,7 +17,7 @@ parameters:
   publishOutputSuffix: ''                                   # the artifact suffix to use when publishing the output folder
   signListPath: 'SignList.xml'                              # the path to the SignList.xml to copy into the nuget artifact for signing
   # job software version parameters
-  agentPool: 'Azure Pipelines'                              # the name of the Azure VM pool
+  agentPoolName: 'Azure Pipelines'                          # the name of the Azure VM pool
   linuxImage: ''                                            # the name of the Linux VM image (linuxImage: 'Hosted Ubuntu 1604') 
   macosImage: 'macos-latest'                                # the name of the macOS VM image
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
@@ -64,7 +64,7 @@ jobs:
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
     dependsOn: ${{ parameters.dependsOn }}
     pool:
-      name: ${{ parameters.agentPool }}
+      name: ${{ parameters.agentPoolName }}
       vmImage: $(imageName)
     steps:
       - checkout: self

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -17,6 +17,7 @@ parameters:
   publishOutputSuffix: ''                                   # the artifact suffix to use when publishing the output folder
   signListPath: 'SignList.xml'                              # the path to the SignList.xml to copy into the nuget artifact for signing
   # job software version parameters
+  agentPool: 'Azure Pipelines'                              # the name of the Azure VM pool
   linuxImage: ''                                            # the name of the Linux VM image (linuxImage: 'Hosted Ubuntu 1604') 
   macosImage: 'macos-latest'                                # the name of the macOS VM image
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
@@ -63,6 +64,7 @@ jobs:
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
     dependsOn: ${{ parameters.dependsOn }}
     pool:
+      name: ${{ parameters.agentPool }}
       vmImage: $(imageName)
     steps:
       - checkout: self


### PR DESCRIPTION
Currently consumers cannot specify the VM pool.  This means it always defaults to `Azure Pipelines`.  Our GPS/FB build now hits the disk space 10 GB disk space limit on Windows, so we need to use a beefier machine in a DevDiv pool.

Adding this template parameter will allow us to specify the DevDiv pool.

Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#pool