### PR TITLE
[build.yml] Separate 'agentPoolName' parameter per platform.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -17,7 +17,9 @@ parameters:
   publishOutputSuffix: ''                                   # the artifact suffix to use when publishing the output folder
   signListPath: 'SignList.xml'                              # the path to the SignList.xml to copy into the nuget artifact for signing
   # job software version parameters
-  agentPoolName: 'Azure Pipelines'                          # the name of the Azure VM pool
+  linuxAgentPoolName: 'Azure Pipelines'                     # the name of the Linux VM pool
+  macosAgentPoolName: 'Azure Pipelines'                     # the name of the macOS VM pool
+  windowsAgentPoolName: 'Azure Pipelines'                   # the name of the Windows VM pool
   linuxImage: ''                                            # the name of the Linux VM image (linuxImage: 'Hosted Ubuntu 1604') 
   macosImage: 'macos-latest'                                # the name of the macOS VM image
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
@@ -52,19 +54,22 @@ jobs:
       matrix:
         ${{ if ne(parameters.linuxImage, '') }}:
           linux:
+            poolName: ${{ parameters.linuxAgentPoolName }}
             imageName: ${{ parameters.linuxImage }}
         ${{ if ne(parameters.macosImage, '') }}:
           macos:
+            poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
         ${{ if ne(parameters.windowsImage, '') }}:
           windows:
+            poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
     dependsOn: ${{ parameters.dependsOn }}
     pool:
-      name: ${{ parameters.agentPoolName }}
+      name: $(poolName)
       vmImage: $(imageName)
     steps:
       - checkout: self


### PR DESCRIPTION
In https://github.com/xamarin/XamarinComponents/pull/1278 we allowed a consumer to specify a pool name instead of just a VM Image name for getting build agents.  Unfortunately this needs to be per-platform, as the desired use case is to use a custom pool for Windows, but the default `Azure Pipelines` pool for mac with a `macos-latest` image.

This PR splits `agentPoolName` into per-platform template parameters.

I verified that it is okay to populate the `vmImage` parameter when not using `Azure Pipelines`.  The value is simply ignored:

![image](https://user-images.githubusercontent.com/179295/134062804-69b714b7-2945-480f-b923-6fd4a551945f.png)
