### PR TITLE
[Guava] Update to 29.0 and target 'net6.0-android31'.

### DIFF
--- a/Android/Guava/Directory.Build.props
+++ b/Android/Guava/Directory.Build.props
@@ -3,12 +3,24 @@
     <!-- Uncomment if a $(PackageVersionSuffix) is ever needed -->
     <!-- <PackageVersionSuffix>-net6preview04</PackageVersionSuffix> -->
     <!-- <PackageVersionSuffix Condition=" '$(BUILD_BUILDID)' != '' ">$(PackageVersionSuffix).$(BUILD_BUILDID)</PackageVersionSuffix> -->
-    <GuavaNuGetVersion>28.2.0.1$(PackageVersionSuffix)</GuavaNuGetVersion>
-    <GuavaFailureAccessNuGetVersion>1.0.1.3$(PackageVersionSuffix)</GuavaFailureAccessNuGetVersion>
-    <GuavaListenableFutureNuGetVersion>1.0.0.3$(PackageVersionSuffix)</GuavaListenableFutureNuGetVersion>
+    <GuavaNuGetVersion>29.0.0$(PackageVersionSuffix)</GuavaNuGetVersion>
+    <GuavaFailureAccessNuGetVersion>1.0.1.4$(PackageVersionSuffix)</GuavaFailureAccessNuGetVersion>
+    <GuavaListenableFutureNuGetVersion>1.0.0.4$(PackageVersionSuffix)</GuavaListenableFutureNuGetVersion>
+    
+    <!-- Opt out of C#8 features to maintain compatibility with legacy -->
+    <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
+    <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
+    <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>false</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
+    
+    <!-- .NET 6+ generates Resource.designer.cs files for bindings projects which we do not want -->
+    <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    
+    <!-- .NET 6+ packages support back to API-21 -->
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+
   </PropertyGroup>
   <ItemGroup>
     <_NuGetBuildFolders Include="build\;buildTransitive\" />
-    <_TfmNuGetBuildFolders Include="@(_NuGetBuildFolders->'%(Identity)monoandroid90\');@(_NuGetBuildFolders->'%(Identity)net6.0-android30.0\')" />
+    <_TfmNuGetBuildFolders Include="@(_NuGetBuildFolders->'%(Identity)monoandroid90\');@(_NuGetBuildFolders->'%(Identity)net6.0-android31.0\')" />
   </ItemGroup>
 </Project>

--- a/Android/Guava/build.cake
+++ b/Android/Guava/build.cake
@@ -2,7 +2,7 @@
 
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var GUAVA_VERSION_BASE = "28.2";
+var GUAVA_VERSION_BASE = "29.0";
 var GUAVA_VERSION = GUAVA_VERSION_BASE + "-android";
 var GUAVA_FAILUREACCESS_VERSION = "1.0.1";
 var GUAVA_LISTENABLEFUTURE_VERSION = "1.0";

--- a/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.csproj
+++ b/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android30;monoandroid90</TargetFrameworks>
+    <TargetFrameworks>net6.0-android;monoandroid90</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Google.Guava.FailureAccess</AssemblyName>
     <RootNamespace>Guava.FailureAccess</RootNamespace>

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android30;monoandroid90</TargetFrameworks>
+    <TargetFrameworks>net6.0-android;monoandroid90</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Google.Guava.ListenableFuture</AssemblyName>
     <RootNamespace>Guava.ListenableFuture</RootNamespace>

--- a/Android/Guava/source/Guava/Guava.csproj
+++ b/Android/Guava/source/Guava/Guava.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android30;monoandroid90</TargetFrameworks>
+    <TargetFrameworks>net6.0-android;monoandroid90</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Google.Guava</AssemblyName>
     <RootNamespace>Guava</RootNamespace>


### PR DESCRIPTION
Diffs are a result of removing unneeded `Resource.Designer.cs` that was added due to a bug in early .NET 6 previews.