### PR TITLE
Binderator suport for interpolation and variables in POM.xml files

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tests/Xamarin.AndroidBinderator.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.5.0</PackageVersion>
+    <PackageVersion>0.5.1</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -326,6 +326,15 @@ namespace AndroidBinderator
 
 					mavenDep.Version = FixVersion(mavenDep.Version, mavenProject);
 
+					if (mavenDep.GroupId.Contains("${project.groupId}"))
+					{
+						mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
+					}
+					if (mavenDep.Version.Contains ("${project.version}"))
+					{
+						mavenDep.Version = mavenDep.Version.Replace ("${project.version}", mavenProject.Version);
+					}
+
 					var depMapping = config.MavenArtifacts.FirstOrDefault(
 						ma => !string.IsNullOrEmpty(ma.Version)
 						&& ma.GroupId == mavenDep.GroupId
@@ -354,8 +363,8 @@ namespace AndroidBinderator
         ""groupId"": ""{mavenDep.GroupId}"",
         ""artifactId"": ""{mavenDep.ArtifactId}"",
         ""version"": ""{mavenDep.Version}"",
-        ""nugetVersion"": ""CHECK NUGET ID"",
-        ""nugetId"": ""CHECK PREFIX {mavenDep.Version}"",
+        ""nugetVersion"": ""CHECK PREFIX {mavenDep.Version}"",
+        ""nugetId"": ""CHECK NUGET VERSION"",
         ""dependencyOnly"": true/false
       }}
 						");

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -326,14 +326,8 @@ namespace AndroidBinderator
 
 					mavenDep.Version = FixVersion(mavenDep.Version, mavenProject);
 
-					if (mavenDep.GroupId.Contains("${project.groupId}"))
-					{
-						mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
-					}
-					if (mavenDep.Version.Contains ("${project.version}"))
-					{
-						mavenDep.Version = mavenDep.Version.Replace ("${project.version}", mavenProject.Version);
-					}
+					mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
+					mavenDep.Version = mavenDep.Version.Replace ("${project.version}", mavenProject.Version);
 
 					var depMapping = config.MavenArtifacts.FirstOrDefault(
 						ma => !string.IsNullOrEmpty(ma.Version)

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.3.0</PackageVersion>
+        <PackageVersion>2.3.1</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ resources:
       ref: refs/heads/main
 
 variables:
-  DotNet6Version: 6.0.100-rc.1.21458.32
+  DotNet6Version: 6.0.100-rc.1.21463.6
   XamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
   # NOTE: there wasn't a public release of 16.11 for macOS
   XamarinAndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg


### PR DESCRIPTION
Binderator was not able to handle interpolation and variables like `${project.groupId}` or `${project.version}` in `pom.xml` files (mainly for dependencies.

This PR adds support for interpolation and variables

From https://github.com/xamarin/GooglePlayServicesComponents/pull/520/.

Sample `POM.xml` (`cronet-common-72.3626.96.pom`):

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

  <modelVersion>4.0.0</modelVersion>

  <groupId>org.chromium.net</groupId>

  <artifactId>cronet-common</artifactId>

  <version>72.3626.96</version>

  <packaging>aar</packaging>

  <name>Cronet</name>

  <description>Cronet shared implementation. Not a complete implementation; apps and libraries should not depend on this target directly.</description>

  <dependencies>

    <dependency>

      <groupId>${project.groupId}</groupId>

      <artifactId>cronet-api</artifactId>

      <version>${project.version}</version>

    </dependency>

  </dependencies>

  <licenses>

    <license>

      <name>Chromium and built-in dependencies</name>

      <url>https://storage.cloud.google.com/chromium-cronet/android/72.0.3626.96/Release/cronet/LICENSE</url>

      <distribution>repo</distribution>

    </license>

  </licenses>

</project>

```