### PR TITLE
fix NET 6 RC version for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ resources:
       ref: refs/heads/main
 
 variables:
-  DotNet6Version: 6.0.100-rc.1.21458.32
+  DotNet6Version: 6.0.100-rc.1.21463.6
   XamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
   # NOTE: there wasn't a public release of 16.11 for macOS
   XamarinAndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg


### PR DESCRIPTION
Seems that older RC and preview versions are removed from storage and builds fail

This PR fixes builds with newest RC version.