### PR TITLE
Binderator dependency version null fix

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <ToolCommandName>xamarin-android-binderator</ToolCommandName>
     <AssemblyName>Xamarin.AndroidBinderator.Tool</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.Tool/Xamarin.AndroidBinderator.Tool.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>Xamarin.AndroidBinderator.Tool</PackageId>
-    <PackageVersion>0.5.1</PackageVersion>
+    <PackageVersion>0.5.2</PackageVersion>
     <Title>Xamarin Android Binderator</Title>
     <PackageDescription>A tool for generating Xamarin.Android Binding projects from Razor templates and Maven Repository data.</PackageDescription>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2100525</PackageProjectUrl>

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -431,7 +431,7 @@ namespace AndroidBinderator
 
 		static bool ShouldIncludeDependency(BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
 		{
-			if (dependency.Version == null)
+			if (dependency.Scope == "test")
 				return false;
 
 			// We always care about 'compile' scoped dependencies

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -439,17 +439,17 @@ namespace AndroidBinderator
 			if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
 				return false;
 
+			// We always care about 'compile' scoped dependencies
+			if (dependency.IsCompileDependency ())
+				return true;
+
 			// If we're not processing Runtime dependencies then ignore the rest
 			if (!config.StrictRuntimeDependencies)
 				return false;
 
 			// The only other thing we may care about is 'runtime', bail if this isn't 'runtime'
-			if (!dependency.IsRuntimeDependency())
+			if (!dependency.IsRuntimeDependency ())
 				return false;
-
-			// We always care about 'compile' scoped dependencies
-			if (dependency.IsCompileDependency ())
-				return true;
 
 			return true;
 		}

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -431,7 +431,9 @@ namespace AndroidBinderator
 
 		static bool ShouldIncludeDependency(BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
 		{
-			if (dependency.Scope == "test")
+			// TODO: MavenNET - implement the stuff to pull version from <dependencyManagement> information
+			//	 from the parent POM.
+			if (string.IsNullOrEmpty(dependency.Version))
 				return false;
 
 			// We always care about 'compile' scoped dependencies

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -327,7 +327,7 @@ namespace AndroidBinderator
 					mavenDep.Version = FixVersion(mavenDep.Version, mavenProject);
 
 					mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
-					mavenDep.Version = mavenDep.Version.Replace ("${project.version}", mavenProject.Version);
+					mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
 
 					var depMapping = config.MavenArtifacts.FirstOrDefault(
 						ma => !string.IsNullOrEmpty(ma.Version)
@@ -358,7 +358,7 @@ namespace AndroidBinderator
         ""artifactId"": ""{mavenDep.ArtifactId}"",
         ""version"": ""{mavenDep.Version}"",
         ""nugetVersion"": ""CHECK PREFIX {mavenDep.Version}"",
-        ""nugetId"": ""CHECK NUGET VERSION"",
+        ""nugetId"": ""CHECK NUGET ID"",
         ""dependencyOnly"": true/false
       }}
 						");
@@ -431,6 +431,9 @@ namespace AndroidBinderator
 
 		static bool ShouldIncludeDependency(BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
 		{
+			if (dependency.Version == null)
+				return false;
+
 			// We always care about 'compile' scoped dependencies
 			if (dependency.IsCompileDependency())
 				return true;

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -431,14 +431,13 @@ namespace AndroidBinderator
 
 		static bool ShouldIncludeDependency(BindingConfig config, MavenArtifactConfig artifact, Dependency dependency, List<Exception> exceptions)
 		{
-			// TODO: MavenNET - implement the stuff to pull version from <dependencyManagement> information
-			//	 from the parent POM.
-			if (string.IsNullOrEmpty(dependency.Version))
+			// Check 'artifact' list
+			if (artifact.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
 				return false;
 
-			// We always care about 'compile' scoped dependencies
-			if (dependency.IsCompileDependency())
-				return true;
+			// Check 'global' list
+			if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
+				return false;
 
 			// If we're not processing Runtime dependencies then ignore the rest
 			if (!config.StrictRuntimeDependencies)
@@ -448,13 +447,9 @@ namespace AndroidBinderator
 			if (!dependency.IsRuntimeDependency())
 				return false;
 
-			// Check 'artifact' list
-			if (artifact.ExcludedRuntimeDependencies.OrEmpty().Split(',').Contains(dependency.GroupAndArtifactId(), StringComparer.OrdinalIgnoreCase))
-				return false;
-
-			// Check 'global' list
-			if (config.ExcludedRuntimeDependencies.OrEmpty ().Split (',').Contains (dependency.GroupAndArtifactId (), StringComparer.OrdinalIgnoreCase))
-				return false;
+			// We always care about 'compile' scoped dependencies
+			if (dependency.IsCompileDependency ())
+				return true;
 
 			return true;
 		}

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <PackageVersion>2.3.1</PackageVersion>
+        <PackageVersion>2.3.2</PackageVersion>
         <PackageId>Xamarin.AndroidBinderator</PackageId>
         <Title>Xamarin.AndroidBinderator</Title>
         <PackageDescription>An engine to generate Xamarin Binding projects from Maven repositories with a JSON config and razor templates.</PackageDescription>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,7 @@ jobs:
     parameters:
       timeoutInMinutes: 360
       areaPath: 'DevDiv\Xamarin SDK\Android'
+      xcode: 13.0
       buildType: 'manifest'
       linuxImage: 'ubuntu-latest'
       validPackagePrefixes: 


### PR DESCRIPTION
Fix for handling dependencies without version specified.

binderator could not handle dependencies without version like in `com.google.protobuf:protobuf-lite` POM.xml file

https://repo1.maven.org/maven2/com/google/protobuf/protobuf-lite/3.0.1/protobuf-lite-3.0.1.pom

Following snippet caused NRE:

```xml
<dependencies>
<dependency>
<groupId>junit</groupId>
<artifactId>junit</artifactId>
</dependency>
<dependency>
<groupId>org.easymock</groupId>
<artifactId>easymock</artifactId>
</dependency>
<dependency>
<groupId>org.easymock</groupId>
<artifactId>easymockclassextension</artifactId>
</dependency>
</dependencies>
```

Details:

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
<modelVersion>4.0.0</modelVersion>
<parent>
<groupId>com.google.protobuf</groupId>
<artifactId>protobuf-parent</artifactId>
<version>3.0.0</version>
</parent>
<version>3.0.1</version>
<artifactId>protobuf-lite</artifactId>
<packaging>bundle</packaging>
<name>Protocol Buffers [Lite]</name>
<description>A trimmed-down version of the Protocol Buffers library.</description>
<dependencies>
<dependency>
<groupId>junit</groupId>
<artifactId>junit</artifactId>
</dependency>
<dependency>
<groupId>org.easymock</groupId>
<artifactId>easymock</artifactId>
</dependency>
<dependency>
<groupId>org.easymock</groupId>
<artifactId>easymockclassextension</artifactId>
</dependency>
</dependencies>
<properties>
<core.root>../core</core.root>
<test.proto.dir>${core.root}/src/test/proto</test.proto.dir>
<protoc-gen-javalite>${protobuf.source.dir}/protoc-gen-javalite</protoc-gen-javalite>
</properties>
<build>
<sourceDirectory>${core.root}/src/main/java</sourceDirectory>
<testSourceDirectory>${core.root}/src/test/java</testSourceDirectory>
<plugins>
<!--  Use Antrun plugin to generate sources with protoc  -->
<plugin>
<artifactId>maven-antrun-plugin</artifactId>
<executions>
<!--  Generate core protos  -->
<execution>
<id>generate-sources</id>
<phase>generate-sources</phase>
<configuration>
<target>
<ant antfile="generate-sources-build.xml"/>
</target>
</configuration>
<goals>
<goal>run</goal>
</goals>
</execution>
<!--  Generate the test protos  -->
<execution>
<id>generate-test-sources</id>
<phase>generate-test-sources</phase>
<configuration>
<target>
<ant antfile="generate-test-sources-build.xml"/>
</target>
</configuration>
<goals>
<goal>run</goal>
</goals>
</execution>
</executions>
</plugin>
<!--  Only compile a subset of the files  -->
<plugin>
<artifactId>maven-compiler-plugin</artifactId>
<configuration>
<generatedSourcesDirectory>${generated.sources.lite.dir}</generatedSourcesDirectory>
<generatedTestSourcesDirectory>${generated.testsources.lite.dir}</generatedTestSourcesDirectory>
<includes>
<include>**/AbstractMessageLite.java</include>
<include>**/AbstractParser.java</include>
<include>**/AbstractProtobufList.java</include>
<include>**/BooleanArrayList.java</include>
<include>**/ByteString.java</include>
<include>**/CodedInputStream.java</include>
<include>**/CodedOutputStream.java</include>
<include>**/DoubleArrayList.java</include>
<include>**/ExtensionLite.java</include>
<include>**/ExtensionRegistryLite.java</include>
<include>**/FieldSet.java</include>
<include>**/FloatArrayList.java</include>
<include>**/GeneratedMessageLite.java</include>
<include>**/IntArrayList.java</include>
<include>**/Internal.java</include>
<include>**/InvalidProtocolBufferException.java</include>
<include>**/LazyFieldLite.java</include>
<include>**/LazyStringArrayList.java</include>
<include>**/LazyStringList.java</include>
<include>**/LongArrayList.java</include>
<include>**/MapEntryLite.java</include>
<include>**/MapFieldLite.java</include>
<include>**/MessageLite.java</include>
<include>**/MessageLiteOrBuilder.java</include>
<include>**/MessageLiteToString.java</include>
<include>**/MutabilityOracle.java</include>
<include>**/NioByteString.java</include>
<include>**/Parser.java</include>
<include>**/ProtobufArrayList.java</include>
<include>**/ProtocolStringList.java</include>
<include>**/RopeByteString.java</include>
<include>**/SmallSortedMap.java</include>
<include>**/TextFormatEscaper.java</include>
<include>**/UninitializedMessageException.java</include>
<include>**/UnknownFieldSetLite.java</include>
<include>**/UnmodifiableLazyStringList.java</include>
<include>**/UnsafeByteOperations.java</include>
<include>**/Utf8.java</include>
<include>**/WireFormat.java</include>
</includes>
<testIncludes>
<testInclude>**/*Lite.java</testInclude>
<testInclude>**/BooleanArrayListTest.java</testInclude>
<testInclude>**/DoubleArrayListTest.java</testInclude>
<testInclude>**/FloatArrayListTest.java</testInclude>
<testInclude>**/IntArrayListTest.java</testInclude>
<testInclude>**/LazyMessageLiteTest.java</testInclude>
<testInclude>**/LiteTest.java</testInclude>
<testInclude>**/LongArrayListTest.java</testInclude>
<testInclude>**/NioByteStringTest.java</testInclude>
<testInclude>**/ProtobufArrayListTest.java</testInclude>
<testInclude>**/UnknownFieldSetLiteTest.java</testInclude>
</testIncludes>
</configuration>
</plugin>
<!--  OSGI bundle configuration  -->
<plugin>
<groupId>org.apache.felix</groupId>
<artifactId>maven-bundle-plugin</artifactId>
<extensions>true</extensions>
<configuration>
<instructions>
<Bundle-DocURL>https://developers.google.com/protocol-buffers/</Bundle-DocURL>
<Bundle-SymbolicName>com.google.protobuf</Bundle-SymbolicName>
<Export-Package>com.google.${project.artifactId};version=${project.version}</Export-Package>
</instructions>
</configuration>
</plugin>
</plugins>
</build>
</project>
```