### PR TITLE
[Bug] [Windows] Xamarin.Build.Download Fix Max Path Length Extraction

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Test.cs
@@ -122,7 +122,7 @@ namespace NativeLibraryDownloaderTests
 
 			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
 
-			
+
 			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
 			Assert.True (success);
 
@@ -332,7 +332,7 @@ namespace NativeLibraryDownloaderTests
 			var artifactXbdId = "gpsbasement-16.2.0";
 
 			var r = AndroidAarAdd(unpackDir, artifactXbdId, "https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/16.2.0/play-services-basement-16.2.0.aar", true);
-			
+
 			AssertNoMessagesOrWarnings(r.logs, DEFAULT_IGNORE_PATTERNS);
 			Assert.True(r.success);
 
@@ -361,7 +361,7 @@ namespace NativeLibraryDownloaderTests
 			var engine = new ProjectCollection ();
 			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
 
-			
+
 			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
 			prel.SetProperty ("TargetFrameworkIdentifier", "MonoAndroid");
 			prel.SetProperty ("TargetFrameworkVersion", "v9.0");
@@ -678,7 +678,7 @@ namespace NativeLibraryDownloaderTests
 					{ "RangeStart", "199278205" },
 					{ "RangeEnd", "199589731" },
 				});
-			
+
 			AddCoreTargets (prel);
 
 			var project = new ProjectInstance (prel);
@@ -693,6 +693,38 @@ namespace NativeLibraryDownloaderTests
 
 			Assert.Equal (2, itemToDownload.Count);
 			Assert.True (itemToDownload.First ().GetMetadata ("Url").EvaluatedValue == itemUrl);
+		}
+
+		[Fact]
+		public void TestPathGreaterThan260Chars ()
+		{
+			var engine = new ProjectCollection ();
+			var prel = ProjectRootElement.Create (Path.Combine (TempDir, "project.csproj"), engine);
+
+			var unpackDir = GetTempPath ("unpacked");
+
+			for (var i = 1; unpackDir.Length < 260; i++)
+				unpackDir = Path.Combine (unpackDir, $"segment{i}");
+
+			prel.SetProperty ("XamarinBuildDownloadDir", unpackDir);
+
+			prel.AddItem (
+				"XamarinBuildDownload", "GAppM-8.8.0", new Dictionary<string, string> {
+					{ "Url", "https://dl.google.com/firebase/ios/analytics/86849febfdc4ff13/GoogleAppMeasurement-8.8.0.tar.gz" },
+					{ "Kind", "Tgz" }
+				});
+
+			AddCoreTargets (prel);
+
+			var project = new ProjectInstance (prel);
+			var log = new MSBuildTestLogger ();
+
+			var success = BuildProject (engine, project, "_XamarinBuildDownload", log);
+
+			AssertNoMessagesOrWarnings (log, DEFAULT_IGNORE_PATTERNS);
+			Assert.True (success);
+
+			Assert.True (File.Exists (Path.Combine (unpackDir, "GAppM-8.8.0", "GoogleAppMeasurement-8.8.0", "dummy.txt")));
 		}
 	}
 }

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
@@ -89,9 +89,9 @@ namespace Xamarin.MacDev
 
 		static void AppendQuoted (StringBuilder quoted, string text)
 		{
-			quoted.AppendFormat ("\"");
-			quoted.AppendFormat (text);
-			quoted.AppendFormat ("\"");
+			quoted.Append ("\"");
+			quoted.Append (text);
+			quoted.Append ("\"");
 		}
 
 		/// <summary>Adds an argument, quoting and escaping as necessary.</summary>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/ProcessArgumentBuilder.cs
@@ -33,8 +33,6 @@ namespace Xamarin.MacDev
 	/// </summary>
 	class ProcessArgumentBuilder
 	{
-		static readonly char[] QuoteSpecials = new char[] { ' ', '\\', '\'', '"', ',', ';' };
-
 		readonly HashSet<string> hash = new HashSet<string> ();
 		readonly StringBuilder builder = new StringBuilder ();
 
@@ -91,19 +89,9 @@ namespace Xamarin.MacDev
 
 		static void AppendQuoted (StringBuilder quoted, string text)
 		{
-			if (text.IndexOfAny (QuoteSpecials) != -1) {
-				quoted.Append ("\"");
-
-				for (int i = 0; i < text.Length; i++) {
-					if (text[i] == '\\' || text[i] == '"')
-						quoted.Append ('\\');
-					quoted.Append (text[i]);
-				}
-
-				quoted.Append ("\"");
-			} else {
-				quoted.Append (text);
-			}
+			quoted.AppendFormat ("\"");
+			quoted.AppendFormat (text);
+			quoted.AppendFormat ("\"");
 		}
 
 		/// <summary>Adds an argument, quoting and escaping as necessary.</summary>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Xamarin.Build.Download</PackageId>
     <Title>Xamarin Build-time Download Support</Title>
-    <PackageVersion>0.10.0</PackageVersion>
+    <PackageVersion>0.11.0</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -287,10 +287,22 @@ namespace Xamarin.Build.Download
 			default:
 				throw new ArgumentException ("kind");
 			}
-			return new ProcessStartInfo (args.ProcessPath, args.ToString ()) {
-				WorkingDirectory = contentDir,
-				CreateNoWindow = true
-			};
+
+			ProcessStartInfo psi = null;
+			if (Platform.IsWindows)
+				psi = new ProcessStartInfo (args.ProcessPath, args.ToString ())
+				{
+					WorkingDirectory = null,
+					CreateNoWindow = true
+				};
+			else
+				psi = new ProcessStartInfo (args.ProcessPath, args.ToString ())
+				{
+					WorkingDirectory = contentDir,
+					CreateNoWindow = true
+				};
+
+			return psi;
 		}
 
 		static ProcessArgumentBuilder Build7ZipExtractionArgs (string file, string contentDir, string user7ZipPath, bool ignoreTarSymLinks, string vsInstallRoot)


### PR DESCRIPTION
Fix for issue #1295.

Simplified `AppendQuoted`, now no longer tries to escape `\` or `"` and just wraps the text argument in double quotes  (this I also believe is the same behaviour of [QuotedArgument](https://github.com/cake-build/cake/blob/dc550dd786baf28a63258fd994136a3fd266c1c5/src/Cake.Core/IO/Arguments/QuotedArgument.cs) in Cake). 

As mentioned in the above issue this was found when testing NuGets built from https://github.com/xamarin/GoogleApisForiOSComponents/pull/501 and is a blocking issue as it prevents building in VS for Windows.

New test case added `TestPathGreaterThan260Chars`.

Test have been validated on,

- [x] Windows 10 21H1
- [x] macOS 12.0.1