### PR TITLE
Moshi-1.13.0

### DIFF
--- a/Android/SquareMoshi/build.cake
+++ b/Android/SquareMoshi/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.12.0";
+var NUGET_VERSION = "1.13.0";
 
-var JAR_VERSION = "1.12.0";
+var JAR_VERSION = "1.13.0";
 var JAR_URL = $"https://repo1.maven.org/maven2/com/squareup/moshi/moshi/{JAR_VERSION}/moshi-{JAR_VERSION}.jar";
 
 Task ("externals")

--- a/Android/SquareMoshi/cgmanifest.json
+++ b/Android/SquareMoshi/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "moshi",
           "GroupId": "com.squareup.moshi",
-          "Version": "1.12.0",
+          "Version": "1.13.0",
           "NuGetId": "Square.Moshi"
         }
       }

--- a/Android/SquareMoshi/source/Square.Moshi/Square.Moshi.csproj
+++ b/Android/SquareMoshi/source/Square.Moshi/Square.Moshi.csproj
@@ -23,12 +23,12 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>moshi xamarin android monodroid</PackageTags>
-    <PackageVersion>1.12.0</PackageVersion>
+    <PackageVersion>1.13.0</PackageVersion>
   </PropertyGroup>
     
   <ItemGroup>
     <PackageReference Include="Square.OkiO" Version="2.10.0" />
-    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.4.32.1" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.6.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/Android/SquareMoshiAdapters/build.cake
+++ b/Android/SquareMoshiAdapters/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.12.0";
+var NUGET_VERSION = "1.13.0";
 
-var JAR_VERSION = "1.12.0";
+var JAR_VERSION = "1.13.0";
 var JAR_URL = $"https://repo1.maven.org/maven2/com/squareup/moshi/moshi-adapters/{JAR_VERSION}/moshi-adapters-{JAR_VERSION}.jar";
 
 Task ("externals")

--- a/Android/SquareMoshiAdapters/cgmanifest.json
+++ b/Android/SquareMoshiAdapters/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "moshi-adapters",
           "GroupId": "com.squareup.moshi",
-          "Version": "1.12.0",
+          "Version": "1.13.0",
           "NuGetId": "Square.Moshi.Adapters"
         }
       }

--- a/Android/SquareMoshiAdapters/source/Square.Moshi.Adapters/Square.Moshi.Adapters.csproj
+++ b/Android/SquareMoshiAdapters/source/Square.Moshi.Adapters/Square.Moshi.Adapters.csproj
@@ -23,12 +23,12 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>moshi adapters xamarin android monodroid</PackageTags>
-    <PackageVersion>1.12.0</PackageVersion>
+    <PackageVersion>1.13.0</PackageVersion>
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Square.Moshi" Version="1.12.0" />
-    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.4.32.1" />
+    <PackageReference Include="Square.Moshi" Version="1.13.0" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.6.0" />
   </ItemGroup>
     
   <ItemGroup>

--- a/Android/SquareMoshiKotlin/build.cake
+++ b/Android/SquareMoshiKotlin/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.12.0";
+var NUGET_VERSION = "1.13.0";
 
-var JAR_VERSION = "1.12.0";
+var JAR_VERSION = "1.13.0";
 var JAR_URL = $"https://repo1.maven.org/maven2/com/squareup/moshi/moshi-kotlin/{JAR_VERSION}/moshi-kotlin-{JAR_VERSION}.jar";
 
 Task ("externals")

--- a/Android/SquareMoshiKotlin/cgmanifest.json
+++ b/Android/SquareMoshiKotlin/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "moshi-kotlin",
           "GroupId": "com.squareup.moshi",
-          "Version": "1.12.0",
+          "Version": "1.13.0",
           "NuGetId": "Square.Moshi.Kotlin"
         }
       }

--- a/Android/SquareMoshiKotlin/source/Square.Moshi.Kotlin/Square.Moshi.Kotlin.csproj
+++ b/Android/SquareMoshiKotlin/source/Square.Moshi.Kotlin/Square.Moshi.Kotlin.csproj
@@ -23,13 +23,13 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>moshi kotlin xamarin android monodroid</PackageTags>
-    <PackageVersion>1.12.0</PackageVersion>
+    <PackageVersion>1.13.0</PackageVersion>
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Square.Moshi" Version="1.12.0" />
-    <PackageReference Include="Xamarin.Kotlin.Reflect" Version="1.4.32.1" />
-    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.4.32.1" />
+    <PackageReference Include="Square.Moshi" Version="1.13.0" />
+    <PackageReference Include="Xamarin.Kotlin.Reflect" Version="1.6.0" />
+    <PackageReference Include="Xamarin.Kotlin.StdLib" Version="1.6.0" />
   </ItemGroup>
     
   <ItemGroup>


### PR DESCRIPTION
~~This PR depends on https://github.com/xamarin/AndroidX/pull/436 and can only be merged after it.~~

This PR updates Moshi, Moshi-Kotlin and Moshi-Adapters to 1.13.0.