### PR TITLE
[guava] fix class libraries and `guava-listenablefuture.jar`

### DIFF
--- a/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.targets
+++ b/Android/Guava/source/Guava.FailureAccess/Guava.FailureAccess.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
     <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
   </ItemGroup>
 </Project>

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.targets
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
     <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/XamarinComponents/issues/1312

If you do:

    $ mkdir foo ; cd foo
    $ dotnet new mauilib
    $ dotnet pack

You end up redistributing `com.google.common.util.concurrent.ListenableFuture`
in your MAUI class library NuGet package:

* `foo.1.0.0.nupkg`
    * `lib\net6.0-android31.0\foo.aar`
        * `libs\78C2212B1AE12Ed.jar`
            * `com\google\common\util\concurrent\ListenableFuture.class`

I tracked this down to here:

https://github.com/xamarin/XamarinComponents/blob/3a9b39733fbd5a5359386ccecbd5f890eb391b1f/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.targets#L3-L5

I believe this needs to check `'$(AndroidApplication)' == 'true'`,
same as we do in AndroidX:

https://github.com/xamarin/AndroidX/blob/ef55d3c8c31c322fedf7fd328afc58ea576035ce/source/AndroidXTargets.cshtml#L51-L53

Let's fix this one package for now, and it might be worth auditing
other packages in this repo later on.