### PR TITLE
AudioSwitch-1.1.4

### DIFF
--- a/Android/AudioSwitch/build.cake
+++ b/Android/AudioSwitch/build.cake
@@ -1,8 +1,8 @@
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.1.3";
+var NUGET_VERSION = "1.1.4";
 
-var AAR_VERSION = "1.1.3";
+var AAR_VERSION = "1.1.4";
 var AAR_URL = $"https://repo1.maven.org/maven2/com/twilio/audioswitch/{AAR_VERSION}/audioswitch-{AAR_VERSION}.aar";
 
 Task ("externals")

--- a/Android/AudioSwitch/cgmanifest.json
+++ b/Android/AudioSwitch/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "audioswitch",
           "GroupId": "com.twilio",
-          "Version": "1.1.3",
+          "Version": "1.1.4",
           "NuGetId": "Xamarin.Twilio.AudioSwitch"
         }
       }

--- a/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
+++ b/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>monoandroid12.0</TargetFrameworks>
+    <TargetFrameworks>monoandroid11.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Twilio.AudioSwitch</AssemblyName>
     <RootNamespace>Xamarin.Twilio.AudioSwitch</RootNamespace>

--- a/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
+++ b/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>monoandroid9.0</TargetFrameworks>
+    <TargetFrameworks>monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Twilio.AudioSwitch</AssemblyName>
     <RootNamespace>Xamarin.Twilio.AudioSwitch</RootNamespace>
@@ -22,7 +22,7 @@
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>audioswitch xamarin android monodroid</PackageTags>
-    <PackageVersion>1.1.3</PackageVersion>
+    <PackageVersion>1.1.4</PackageVersion>
   </PropertyGroup>
     
   <ItemGroup>

--- a/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
+++ b/Android/AudioSwitch/source/AudioSwitch/AudioSwitch.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>monoandroid11.0</TargetFrameworks>
+    <TargetFrameworks>monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <AssemblyName>Xamarin.Twilio.AudioSwitch</AssemblyName>
     <RootNamespace>Xamarin.Twilio.AudioSwitch</RootNamespace>


### PR DESCRIPTION
AudioSwitch 1.1.3 added support to Android 12, because of the bluetooth changes, but also introduced some bugs.
AudioSwitch 1.1.4 fixes those bugs.