### PR TITLE
[ci] Add 'windowsImageOverride' parameter to access 1ES hardened images.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -26,6 +26,7 @@ parameters:
                                                             # macOS-latest = macOS-10.15
                                                             # macOS-11 required for XCode 13.1
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
+  windowsImageOverride: ''                                  # used to access 1ES hardened images
   mono: 'Latest'                                            # the version of mono to use
   xcode: '13.1'                                             # the version of Xcode to use
   dotnet: '6.0.100'                                         # the version of .NET Core to use
@@ -74,6 +75,9 @@ jobs:
     pool:
       name: $(poolName)
       vmImage: $(imageName)
+      ${{ if ne(parameters.windowsImageOverride, '') }}:
+        demands: 
+        - ImageOverride -equals ${{ parameters.windowsImageOverride }}
     steps:
       - checkout: self
         submodules: ${{ parameters.submodules }}


### PR DESCRIPTION
In order to access the 1ES hardened Windows image, we need to specify the following YAML `ImageOverride` which is not currently supported:

```yaml
  pool:
    name: $(1ESWindowsPool)
    demands: 
    - ImageOverride -equals $(1ESWindowsImage)
```

Add an `windowsImageOverride` template parameter to trigger this syntax.