### PR TITLE
[ci] Support for EO agent pools

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -26,7 +26,7 @@ parameters:
                                                             # macOS-latest = macOS-10.15
                                                             # macOS-11 required for XCode 13.1
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
-  windowsImageOverride: ''                                  # used to access 1ES hardened images: name of ImageOverride demand to use such as AzurePipelinesWindows2019compliant when windowsAgentPoolName set to the AzurePipelines-EO pool
+  windowsImageOverride: ''                                  # used to access 1ES hardened images: name of ImageOverride demand to use such as AzurePipelinesWindows2022compliant when windowsAgentPoolName set to the AzurePipelines-EO pool
   mono: 'Latest'                                            # the version of mono to use
   xcode: '13.1'                                             # the version of Xcode to use
   dotnet: '6.0.100'                                         # the version of .NET Core to use

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -64,7 +64,7 @@ jobs:
           macos:
             poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
-        ${{ if ne(parameters.windowsImage, '') }}:
+        ${{ if or(ne(parameters.windowsImage, ''), ne(parameters.windowsImageOverride, '')) }}:
           windows:
             poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -78,9 +78,6 @@ jobs:
     pool:
       name: $(poolName)
       vmImage: $(imageName)
-      ${{ if ne(parameters.windowsImageOverride, '') }}:
-        demands: 
-        - ImageOverride -equals ${{ parameters.windowsImageOverride }}
     steps:
       - checkout: self
         submodules: ${{ parameters.submodules }}

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -64,7 +64,7 @@ jobs:
           macos:
             poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
-        ${{ if or(ne(parameters.windowsImage, ''), ne(parameters.windowsImageOverride, '')) }}:
+        ${{ if or(ne(parameters.windowsAgentPoolName, 'Azure Pipelines'), ne(parameters.windowsImage, ''), ne(parameters.windowsImageOverride, '')) }}:
           windows:
             poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -64,13 +64,10 @@ jobs:
           macos:
             poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
-        ${{ if or(ne(parameters.windowsImage, ''), ne(parameters.windowsImageOverride, '')) }}:
+        ${{ if ne(parameters.windowsImage, '') }}:
           windows:
             poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}
-            ${{ if ne(parameters.windowsImageOverride, '') }}:
-              demands:
-              - ImageOverride -equals ${{ parameters.windowsImageOverride }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
@@ -78,6 +75,9 @@ jobs:
     pool:
       name: $(poolName)
       vmImage: $(imageName)
+      ${{ if and(eq(variables['System.JobName'], 'windows'), ne(parameters.windowsImageOverride, '')) }}:
+        demands:
+        - ImageOverride -equals ${{ parameters.windowsImageOverride }}
     steps:
       - checkout: self
         submodules: ${{ parameters.submodules }}

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -26,7 +26,7 @@ parameters:
                                                             # macOS-latest = macOS-10.15
                                                             # macOS-11 required for XCode 13.1
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
-  windowsImageOverride: ''                                  # used to access 1ES hardened images
+  windowsImageOverride: ''                                  # used to access 1ES hardened images: name of ImageOverride demand to use such as AzurePipelinesWindows2019compliant when windowsAgentPoolName set to the AzurePipelines-EO pool
   mono: 'Latest'                                            # the version of mono to use
   xcode: '13.1'                                             # the version of Xcode to use
   dotnet: '6.0.100'                                         # the version of .NET Core to use
@@ -64,10 +64,13 @@ jobs:
           macos:
             poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
-        ${{ if ne(parameters.windowsImage, '') }}:
+        ${{ if or(ne(parameters.windowsImage, ''), ne(parameters.windowsImageOverride, '')) }}:
           windows:
             poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}
+            ${{ if ne(parameters.windowsImageOverride, '') }}:
+              demands:
+              - ImageOverride -equals ${{ parameters.windowsImageOverride }}
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
       areaPath: 'DevDiv\Xamarin SDK\Android'
       macosImage: 'macOS-11'                                  # the name of the macOS VM image
                                                               # BigSur 20211120
+      windowsImage: 'windows-2019'
       xcode: 13.1
       buildType: 'manifest'
       linuxImage: 'ubuntu-latest'


### PR DESCRIPTION
Related work item: VS #[1488096](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1488096)

Follow up to https://github.com/xamarin/XamarinComponents/pull/1330.  This PR helps ensure that the `windowsImageOverride` setting is only applied to windows jobs.  Plus ensures that the windows job will execute when `windowsImageOverride` is set and `windowsImage` is not. Finally, allows for targeting Windows pools by name and not just by the image name.

Per Executive Order (EO) builds must target secured agent pools such as the `AzurePipelines-EO` pool.  To target such a pool you need to specify the ImageOverride demand as in the following example:

pool:
&nbsp;&nbsp;name: 'AzurePipelines-EO'
&nbsp;&nbsp;demands:
&nbsp;&nbsp;- ImageOverride -equals AzurePipelinesWindows2022compliant