### PR TITLE
[ci] Target windows EO compliant agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ variables:
   # NOTE: there wasn't a public release of 16.11 for macOS
   XamarinAndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
 jobs:
-  - template: .ci/build.yml@components
+  - template: .ci/build.v1.yml@components
     parameters:
       timeoutInMinutes: 360
       areaPath: 'DevDiv\Xamarin SDK\Android'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,9 @@ jobs:
       areaPath: 'DevDiv\Xamarin SDK\Android'
       macosImage: 'macOS-11'                                  # the name of the macOS VM image
                                                               # BigSur 20211120
-      windowsImage: 'windows-2019'
+      windowsAgentPoolName: AzurePipelines-EO
+      windowsImage: ''
+      windowsImageOverride: AzurePipelinesWindows2019compliant
       xcode: 13.1
       buildType: 'manifest'
       linuxImage: 'ubuntu-latest'


### PR DESCRIPTION
Per Executive Order (EO) migrate all jobs that currently use a Windows hosted pool to instead use the `AzurePipelines-EO` agent pool instead.

Executive Order
https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/buildinfraops

Solution made possible by https://github.com/xamarin/XamarinComponents/pull/1333. The `XamarinComponents` build leverages the same templates made available to external repos to build itself.
