### PR TITLE
Update GoogleGson library to 2.8.9

### DIFF
--- a/Android/GoogleGson/build.cake
+++ b/Android/GoogleGson/build.cake
@@ -1,7 +1,7 @@
 
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var JAR_VERSION = "2.8.6";
+var JAR_VERSION = "2.8.9";
 var NUGET_VERSION = JAR_VERSION;
 
 var JAR_URL = string.Format ("http://search.maven.org/remotecontent?filepath=com/google/code/gson/gson/{0}/gson-{0}.jar", JAR_VERSION);

--- a/Android/GoogleGson/cgmanifest.json
+++ b/Android/GoogleGson/cgmanifest.json
@@ -6,7 +6,7 @@
           "Maven": {
             "ArtifactId": "gson",
             "GroupId": "com.google.code.gson",
-            "Version": "2.8.6"
+            "Version": "2.8.9"
           }
         }
       }

--- a/Android/GoogleGson/nuget/GoogleGson.nuspec
+++ b/Android/GoogleGson/nuget/GoogleGson.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>GoogleGson</id>
     <title>Google Gson</title>
-    <version>2.8.6.0</version>
+    <version>2.8.9.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Android/GoogleGson/source/GoogleGson/GoogleGson.csproj
+++ b/Android/GoogleGson/source/GoogleGson/GoogleGson.csproj
@@ -24,7 +24,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865089</PackageProjectUrl>
     <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865037</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>2.8.6</PackageVersion>
+    <PackageVersion>2.8.9</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/117265/alert/6140652

Updates GoogleGson to version 2.8.9 to include a security fix.