### PR TITLE
Linux build: Target AzurePipelines-EO agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,5 +81,5 @@ jobs:
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
-        dependsOn: [ 'build' ]
+        dependsOn: [ 'linux', 'macos', 'windows' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   - main
   - refs/tags/*
-  
+
 pr:
   - main
 
@@ -33,10 +33,15 @@ jobs:
       windowsAgentPoolName: AzurePipelines-EO
       windowsImage: ''
       windowsImageOverride: AzurePipelinesWindows2019compliant
+
       xcode: 13.1
       buildType: 'manifest'
-      linuxImage: 'ubuntu-latest'
-      validPackagePrefixes: 
+
+      linuxAgentPoolName: AzurePipelines-EO
+      linuxsImage: ''
+      linuxImageOverride: AzurePipelinesUbuntu20.04compliant
+
+      validPackagePrefixes:
         # Preferred prefixes
         - Xamarin
         - Mono


### PR DESCRIPTION
Related PR: https://github.com/xamarin/XamarinComponents/pull/1343

Aside from targeting the Linux pool, this also fixes a break in main introduced by https://github.com/xamarin/XamarinComponents/pull/1343 by updating the signing job dependencies to be dependent on the specific OS jobs: `linux`, `macos` and `windows`

The build break was due to XamarinComponents signing step depending on a `build` job, which is an implicit job name used for the matrix build.  The `build` job was effectively removed by https://github.com/xamarin/XamarinComponents/pull/1343 and replaced by the constituent OS jobs: `linux`, `macos` and `windows`
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5838021&view=results