### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,3 +88,12 @@ jobs:
       parameters:
         dependsOn: [ 'linux', 'macos', 'windows' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+    # Executive Order (EO): Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        dependsOn: [ 'signing' ]
+        artifactNames: [ 'nuget-signed' ]
+        packageName: Xamarin.Components         # SBOM package name. TODO: Customize for specific component: Replace with the name of the nuget package such as Square.Moshi.Adapters
+        packageVersionRegex: ''                 # SBOM package version. TODO: Customize for specific component: Regular expression used to glean the version number from the package name such as '(?i)^Square.Moshi.Adapters\.(?<version>\d+\.\d+\.\d+).nupkg$'
+        packageFilter: '*.nupkg'
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')


### PR DESCRIPTION
Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build

**IMPORTANT:** Anyone consuming this in their component branch will need to update the `packageName` and `packageVersionRegex` settings for the SBOM job template to represent the particular component that's produced