### PR TITLE
[ci] Use 'dotnet tool update' instead of 'dotnet tool install' to handle tools already being installed.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -133,13 +133,13 @@ jobs:
       # custom init steps
       - ${{ parameters.initSteps }}
       - pwsh: |
-          dotnet tool install -g api-tools --version ${{ parameters.apiTools }}
-          dotnet tool install -g cake.tool --version ${{ parameters.cake }}
-          dotnet tool install -g Microsoft.DotNet.XHarness.CLI --version ${{ parameters.xharness }} --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
+          dotnet tool update -g api-tools --version ${{ parameters.apiTools }}
+          dotnet tool update -g cake.tool --version ${{ parameters.cake }}
+          dotnet tool update -g Microsoft.DotNet.XHarness.CLI --version ${{ parameters.xharness }} --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json
         displayName: 'Install required .NET Core global tools'
       - ${{ each tool in parameters.tools }}:
         - ${{ each pair in tool }}:
-          - pwsh: dotnet tool install -g ${{ pair.key }} --version ${{ pair.value }}
+          - pwsh: dotnet tool update -g ${{ pair.key }} --version ${{ pair.value }}
             displayName: 'Install additional .NET Core global tool: ${{ pair.key }}'
       - task: NuGetToolInstaller@1
         inputs:


### PR DESCRIPTION
AndroidX/GooglePlayServices switched to using a private agent pool in order to meet the EO requirements.  This pool is elastic, however agents can be reused if they become available while a job is waiting in the queue.

This means that the image may not always be fresh, and `dotnet` global tools that have been installed will already be installed.

Using `dotnet tool install` throws an error if the tool is already installed, however using `dotnet tool update` will install or update the tool without complaining.  Switch to using `update` to support agent reuse.

```
Tool 'api-tools' is already installed.
Tool 'cake.tool' is already installed.
Tool 'microsoft.dotnet.xharness.cli' is already installed.
##[error]PowerShell exited with code '1'.
```