### PR TITLE
[XBD] Changing XBD MasterBeforeTargets value on .net6.0-ios builds

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Xamarin.Build.Download</PackageId>
     <Title>Xamarin Build-time Download Support</Title>
-    <PackageVersion>0.11.0</PackageVersion>
+    <PackageVersion>0.11.1</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -12,6 +12,7 @@
 
 	<PropertyGroup Condition="('$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetPlatformIdentifier)'=='ios') and ('$(OutputType)' != 'Library' or '$(IsAppExtension)'=='True')">
 		<_XamarinBuildDownloadMasterBeforeTargets>GetFrameworkPaths</_XamarinBuildDownloadMasterBeforeTargets>
+		<_XamarinBuildDownloadMasterBeforeTargets Condition="$(TargetFramework.Contains('-ios'))">_BeforeCoreCompileInterfaceDefinitions</_XamarinBuildDownloadMasterBeforeTargets>
 		<_XamarinBuildDownloadMasterDependsOnTargets>_XamarinBuildDownload;_XamarinBuildCastAssemblyResources</_XamarinBuildDownloadMasterDependsOnTargets>
 	</PropertyGroup>
 

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -167,6 +167,7 @@ namespace Xamarin.Build.Download
 						};
 						using (var client = new WebClient ()) {
 							client.DownloadProgressChanged += downloadHandler;
+							client.Headers.Add ("User-Agent: Mozilla/5.0");
 							LogMessage ("  Downloading {0} to {1}", xbd.Url, xbd.CacheFile);
 							client.DownloadFileTaskAsync (xbd.Url, xbd.CacheFile).Wait (token);
 


### PR DESCRIPTION
With .net6.0-ios builds, executing XBD before `GetFrameworkPaths` target is too late.

At this point frameworks bundles downloaded with XBD are embedded correctly to the build but not processed nor copied to the final .app due to `_CollectBundleResources` target is executed once and way before `GetFrameworkPaths` on .net6.0.

Although `_CollectBundleResources` target is called multiple times during the build, with .net6.0 it's designed to be executed once per RID to save time.

This PR overrides the `MasterBeforeTargets` property with .net6.0 builds so stuff downloaded using XBD are embedded at a proper time.

Also, it seems that https://search.maven.org/ needs the User-Agent header to not throw a 403