### PR TITLE
Reinstate dynamic job name in build.v1.yml

### DIFF
--- a/.ci/build.v1.yml
+++ b/.ci/build.v1.yml
@@ -58,7 +58,7 @@ parameters:
 
 jobs:
 - ${{ if or(ne(parameters.linuxAgentPoolName, 'Azure Pipelines'), ne(parameters.linuxImage, '')) }}:
-  - job: linux
+  - job: ${{ parameters.name }}
     displayName: '${{ parameters.displayName }} linux'
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
@@ -119,7 +119,7 @@ jobs:
 
 
 - ${{ if ne(parameters.macosImage, '') }}:
-  - job: macos
+  - job: ${{ parameters.name }}
     displayName: '${{ parameters.displayName }} macos'
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}


### PR DESCRIPTION
As part of #1343 the job names became hardcoded which is an issue if you use this yml file as a template and repeat it multiple times for different steps as we do [in Essentials](https://github.com/xamarin/Essentials/blob/main/azure-pipelines.yml). See an example of the error in Azure DevOps below:

![image](https://user-images.githubusercontent.com/939291/161231774-1044d9e5-d211-4e00-98e7-34a57533f5ee.png)

This PR reinstates the dynamic job name again that is determined through the `name` parameter.

As seen here, this works for our build: https://github.com/xamarin/Essentials/pull/1985