### PR TITLE
Update build.steps.v1.yml

### DIFF
--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -58,7 +58,7 @@ steps:
   # before the build starts, make sure the tooling is as expected
   - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
     displayName: 'Switch to the latest Xamarin SDK'
-    condition: ne(${{ parameters.macosImage, '')
+    condition: ne(${{ parameters.macosImage }}, '')
   - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_${{ parameters.xcode }}.app;sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcode }}.app/Contents/Developer
     displayName: 'Switch to the latest Xcode'
     condition: ne(${{ parameters.macosImage }}, '')

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -90,7 +90,7 @@ steps:
         certSecureFile: 'Components Mac Certificate.p12'
   - bash: echo '##vso[task.setvariable variable=PATH;]'$PATH:$HOME/.dotnet/tools
     displayName: 'Add ~/.dotnet/tools to the PATH environment variable'
-    condition: or(eq( variables['Agent.OS'], 'Darwin' ), ne(eq( variables['Agent.OS'], 'Linux' ))
+    condition: or(eq( variables['Agent.OS'], 'Darwin' ), eq( variables['Agent.OS'], 'Linux' ))
   - task: UseDotNet@2
     displayName: 'Switch to the correct version of the .NET Core SDK'
     inputs:

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -58,39 +58,39 @@ steps:
   # before the build starts, make sure the tooling is as expected
   - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
     displayName: 'Switch to the latest Xamarin SDK'
-    condition: eq(variables['System.JobName'], 'macos')
+    condition: ne(parameters.macosImage, '')
   - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_${{ parameters.xcode }}.app;sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcode }}.app/Contents/Developer
     displayName: 'Switch to the latest Xcode'
-    condition: eq(variables['System.JobName'], 'macos')
+    condition: ne(parameters.macosImage, '')
   - ${{ if eq(parameters.installAppleCertificates, 'true') }}:
     - task: InstallAppleProvisioningProfile@1
-      condition: eq(variables['System.JobName'], 'macos')
+      condition: ne(parameters.macosImage, '')
       displayName: 'Install the iOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: eq(variables['System.JobName'], 'macos')
+      condition: ne(parameters.macosImage, '')
       displayName: 'Install the macOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: eq(variables['System.JobName'], 'macos')
+      condition: ne(parameters.macosImage, '')
       displayName: 'Install the tvOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
     - task: InstallAppleCertificate@2
-      condition: eq(variables['System.JobName'], 'macos')
+      condition: ne(parameters.macosImage, '')
       displayName: 'Install the iOS certificate'
       inputs:
         certSecureFile: 'Components iOS Certificate.p12'
     - task: InstallAppleCertificate@2
-      condition: eq(variables['System.JobName'], 'macos')
+      condition: ne(parameters.macosImage, '')
       displayName: 'Install the macOS certificate'
       inputs:
         certSecureFile: 'Components Mac Certificate.p12'
   - bash: echo '##vso[task.setvariable variable=PATH;]'$PATH:$HOME/.dotnet/tools
     displayName: 'Add ~/.dotnet/tools to the PATH environment variable'
-    condition: or(eq(variables['System.JobName'], 'macos'), eq(variables['System.JobName'], 'linux'))
+    condition: or(ne(parameters.macosImage, ''), ne(parameters.linuxImage, ''))
   - task: UseDotNet@2
     displayName: 'Switch to the correct version of the .NET Core SDK'
     inputs:

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -58,39 +58,39 @@ steps:
   # before the build starts, make sure the tooling is as expected
   - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
     displayName: 'Switch to the latest Xamarin SDK'
-    condition: ne('${{ parameters.macosImage }}', '')
+    condition: eq( variables['Agent.OS'], 'Darwin' )
   - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_${{ parameters.xcode }}.app;sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcode }}.app/Contents/Developer
     displayName: 'Switch to the latest Xcode'
-    condition: ne('${{ parameters.macosImage }}', '')
+    condition: eq( variables['Agent.OS'], 'Darwin' )
   - ${{ if eq(parameters.installAppleCertificates, 'true') }}:
     - task: InstallAppleProvisioningProfile@1
-      condition: ne('${{ parameters.macosImage }}', '')
+      condition: eq( variables['Agent.OS'], 'Darwin' )
       displayName: 'Install the iOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne('${{ parameters.macosImage }}', '')
+      condition: eq( variables['Agent.OS'], 'Darwin' )
       displayName: 'Install the macOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne('${{ parameters.macosImage }}', '')
+      condition: eq( variables['Agent.OS'], 'Darwin' )
       displayName: 'Install the tvOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
     - task: InstallAppleCertificate@2
-      condition: ne('${{ parameters.macosImage }}', '')
+      condition: eq( variables['Agent.OS'], 'Darwin' )
       displayName: 'Install the iOS certificate'
       inputs:
         certSecureFile: 'Components iOS Certificate.p12'
     - task: InstallAppleCertificate@2
-      condition: ne('${{ parameters.macosImage }}', '')
+      condition: eq( variables['Agent.OS'], 'Darwin' )
       displayName: 'Install the macOS certificate'
       inputs:
         certSecureFile: 'Components Mac Certificate.p12'
   - bash: echo '##vso[task.setvariable variable=PATH;]'$PATH:$HOME/.dotnet/tools
     displayName: 'Add ~/.dotnet/tools to the PATH environment variable'
-    condition: or(ne('${{ parameters.macosImage }}', ''), ne('${{ parameters.linuxImage }}', ''))
+    condition: or(eq( variables['Agent.OS'], 'Darwin' ), ne(eq( variables['Agent.OS'], 'Linux' ))
   - task: UseDotNet@2
     displayName: 'Switch to the correct version of the .NET Core SDK'
     inputs:

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -58,39 +58,39 @@ steps:
   # before the build starts, make sure the tooling is as expected
   - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
     displayName: 'Switch to the latest Xamarin SDK'
-    condition: ne(${{ parameters.macosImage }}, '')
+    condition: ne('${{ parameters.macosImage }}', '')
   - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_${{ parameters.xcode }}.app;sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcode }}.app/Contents/Developer
     displayName: 'Switch to the latest Xcode'
-    condition: ne(${{ parameters.macosImage }}, '')
+    condition: ne('${{ parameters.macosImage }}', '')
   - ${{ if eq(parameters.installAppleCertificates, 'true') }}:
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(${{ parameters.macosImage }}, '')
+      condition: ne('${{ parameters.macosImage }}', '')
       displayName: 'Install the iOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(${{ parameters.macosImage }}, '')
+      condition: ne('${{ parameters.macosImage }}', '')
       displayName: 'Install the macOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(${{ parameters.macosImage }}, '')
+      condition: ne('${{ parameters.macosImage }}', '')
       displayName: 'Install the tvOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
     - task: InstallAppleCertificate@2
-      condition: ne(${{ parameters.macosImage }}, '')
+      condition: ne('${{ parameters.macosImage }}', '')
       displayName: 'Install the iOS certificate'
       inputs:
         certSecureFile: 'Components iOS Certificate.p12'
     - task: InstallAppleCertificate@2
-      condition: ne(${{ parameters.macosImage }}, '')
+      condition: ne('${{ parameters.macosImage }}', '')
       displayName: 'Install the macOS certificate'
       inputs:
         certSecureFile: 'Components Mac Certificate.p12'
   - bash: echo '##vso[task.setvariable variable=PATH;]'$PATH:$HOME/.dotnet/tools
     displayName: 'Add ~/.dotnet/tools to the PATH environment variable'
-    condition: or(ne(${{ parameters.macosImage }}, ''), ne(${{ parameters.linuxImage }}, ''))
+    condition: or(ne('${{ parameters.macosImage }}', ''), ne('${{ parameters.linuxImage }}', ''))
   - task: UseDotNet@2
     displayName: 'Switch to the correct version of the .NET Core SDK'
     inputs:

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -58,39 +58,39 @@ steps:
   # before the build starts, make sure the tooling is as expected
   - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
     displayName: 'Switch to the latest Xamarin SDK'
-    condition: ne(parameters.macosImage, '')
+    condition: ne(${{ parameters.macosImage, '')
   - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_${{ parameters.xcode }}.app;sudo xcode-select --switch /Applications/Xcode_${{ parameters.xcode }}.app/Contents/Developer
     displayName: 'Switch to the latest Xcode'
-    condition: ne(parameters.macosImage, '')
+    condition: ne(${{ parameters.macosImage }}, '')
   - ${{ if eq(parameters.installAppleCertificates, 'true') }}:
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(parameters.macosImage, '')
+      condition: ne(${{ parameters.macosImage }}, '')
       displayName: 'Install the iOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components iOS Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(parameters.macosImage, '')
+      condition: ne(${{ parameters.macosImage }}, '')
       displayName: 'Install the macOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components Mac Provisioning.mobileprovision'
     - task: InstallAppleProvisioningProfile@1
-      condition: ne(parameters.macosImage, '')
+      condition: ne(${{ parameters.macosImage }}, '')
       displayName: 'Install the tvOS provisioning profile'
       inputs:
         provProfileSecureFile: 'Components tvOS Provisioning.mobileprovision'
     - task: InstallAppleCertificate@2
-      condition: ne(parameters.macosImage, '')
+      condition: ne(${{ parameters.macosImage }}, '')
       displayName: 'Install the iOS certificate'
       inputs:
         certSecureFile: 'Components iOS Certificate.p12'
     - task: InstallAppleCertificate@2
-      condition: ne(parameters.macosImage, '')
+      condition: ne(${{ parameters.macosImage }}, '')
       displayName: 'Install the macOS certificate'
       inputs:
         certSecureFile: 'Components Mac Certificate.p12'
   - bash: echo '##vso[task.setvariable variable=PATH;]'$PATH:$HOME/.dotnet/tools
     displayName: 'Add ~/.dotnet/tools to the PATH environment variable'
-    condition: or(ne(parameters.macosImage, ''), ne(parameters.linuxImage, ''))
+    condition: or(ne(${{ parameters.macosImage }}, ''), ne(${{ parameters.linuxImage }}, ''))
   - task: UseDotNet@2
     displayName: 'Switch to the correct version of the .NET Core SDK'
     inputs:


### PR DESCRIPTION
It seems like `variables['System.JobName']` isn't really reliable as it returns `__default`. Also, because of the change in #1354 the job name is now dynamic (again).

![image](https://user-images.githubusercontent.com/939291/161535425-e055d39c-3725-42d9-a6b2-8eab3ae07fda.png)

Because of this jobs were being skipped in our pipeline where they shouldn't be, causing build failures. This change adds checks if the agent is running on Darwin (macOS) or Linux for better handling of these scenarios