### PR TITLE
[Guava] Add escape hatches for jar includes.

### DIFF
--- a/Android/Guava/Directory.Build.props
+++ b/Android/Guava/Directory.Build.props
@@ -3,9 +3,9 @@
     <!-- Uncomment if a $(PackageVersionSuffix) is ever needed -->
     <!-- <PackageVersionSuffix>-net6preview04</PackageVersionSuffix> -->
     <!-- <PackageVersionSuffix Condition=" '$(BUILD_BUILDID)' != '' ">$(PackageVersionSuffix).$(BUILD_BUILDID)</PackageVersionSuffix> -->
-    <GuavaNuGetVersion>31.1.0$(PackageVersionSuffix)</GuavaNuGetVersion>
+    <GuavaNuGetVersion>31.1.0.1$(PackageVersionSuffix)</GuavaNuGetVersion>
     <GuavaFailureAccessNuGetVersion>1.0.1.6$(PackageVersionSuffix)</GuavaFailureAccessNuGetVersion>
-    <GuavaListenableFutureNuGetVersion>1.0.0.6$(PackageVersionSuffix)</GuavaListenableFutureNuGetVersion>
+    <GuavaListenableFutureNuGetVersion>1.0.0.7$(PackageVersionSuffix)</GuavaListenableFutureNuGetVersion>
     
     <!-- Opt out of C#8 features to maintain compatibility with legacy -->
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.targets
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' ">
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' And '$(XamarinGoogleGuavaListenableFutureOptOut)' != 'true' ">
     <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
   </ItemGroup>
 </Project>

--- a/Android/Guava/source/Guava/Guava.targets
+++ b/Android/Guava/source/Guava/Guava.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <EmbeddedReferenceJar Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
+  <ItemGroup Condition=" '$(AndroidApplication)' == 'true' And '$(XamarinGoogleGuavaOptOut)' != 'true' ">
+    <AndroidJavaLibrary Include="$(MSBuildThisFileDirectory)..\..\jar\*.jar" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We are currently facing 2 issues related to the way Guava packages have been built.

### Referencing Guava and Guava.ListenableFuture

After Guava was shipped, Google copied the `ListenableFuture` type to a separate package for users who did not want to bring in all of Guava.  However, this type is also still in the Guava package.  Referencing both of these packages causes both the `guava.jar` and `guava-listenablefuture.jar` packages to be added to the final application.  This results in an error like:

```
error : java.lang.RuntimeException: com.android.tools.r8.CompilationFailedException: Compilation failed to complete, 
origin: \.nuget\packages\xamarin.google.guava.listenablefuture\1.0.0.5\buildTransitive\net6.0-android31.0\..\..\jar\guava-
listenablefuture.jar : com/google/common/util/concurrent/ListenableFuture.class
```

This PR adds an opt-out for the `guava-listenablefuture.jar` package that users can specify in their `.csproj` to prevent it from being added to the final application.  This should prevent the duplicate class error:

```xml
<XamarinGoogleGuavaListenableFutureOptOut>true</XamarinGoogleGuavaListenableFutureOptOut>
```

This workaround was added in `Xamarin.Google.Guava.ListenableFuture` `1.0.0.7`.

We will be working on an automatic fix for this, but hopefully this should unblock people for now.

### Multiple Guava Packages

Because `guava.jar` has traditionally been added as `<EmbeddedReferenceJar>`, a copy of it is placed inside each Android bindings library that depends on it.  If 2 bindings libraries reference different versions of `guava.jar` then there are duplicate incompatible versions which can cause as error.

Going forward, we will bind `guava.jar` as `<AndroidJavaLibrary>`. This mode does not include a copy of `guava.jar` in the bindings libraries.  Instead, it is added from the transitive NuGet package to the final application so only the highest version of it will get added.

However, this may cause issues in the interim until bindings libraries are updated.  To facilitate this, an opt-out mechanism has been added that users can add to the `.csproj` to prevent the NuGet `guava.jar` from being added to the application.  This may prevent the duplicates until bindings can be updated:

```xml
<XamarinGoogleGuavaOptOut>true</XamarinGoogleGuavaOptOut>
```

This workaround was added in `Xamarin.Google.Guava` `31.1.0.1`.