### PR TITLE
[Guava.ListenableFuture] Create a 9999.0 version without the .jar to match Maven.

### DIFF
--- a/Android/Guava/Directory.Build.props
+++ b/Android/Guava/Directory.Build.props
@@ -5,7 +5,7 @@
     <!-- <PackageVersionSuffix Condition=" '$(BUILD_BUILDID)' != '' ">$(PackageVersionSuffix).$(BUILD_BUILDID)</PackageVersionSuffix> -->
     <GuavaNuGetVersion>31.1.0.1$(PackageVersionSuffix)</GuavaNuGetVersion>
     <GuavaFailureAccessNuGetVersion>1.0.1.6$(PackageVersionSuffix)</GuavaFailureAccessNuGetVersion>
-    <GuavaListenableFutureNuGetVersion>1.0.0.7$(PackageVersionSuffix)</GuavaListenableFutureNuGetVersion>
+    <GuavaListenableFutureNuGetVersion>9999.0</GuavaListenableFutureNuGetVersion>
     
     <!-- Opt out of C#8 features to maintain compatibility with legacy -->
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>

--- a/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
+++ b/Android/Guava/source/Guava.ListenableFuture/Guava.ListenableFuture.csproj
@@ -15,6 +15,12 @@
     <PackageDescription>
 Xamarin.Android bindings for Google Guava ListenableFuture
 
+NOTE: This version (9999.0) of this package is not intended to be used directly. It does not provide
+a 'guava-listenablefuture.jar'.  This version is used when a project references both Guava and 
+Guava.ListenableFuture.  In this scenario, the only type normally in this package (ListenableFuture.class) is
+provided in 'guava.jar' instead.  This avoids creating a Java error with duplicating this type that
+happens when both .jar's are included in an application.
+
 NOTE: This package is meant to be used as a reference only for other binding projects that depend on Guava.
 This package does not expose any useful API's in the .dll itself.
 
@@ -30,8 +36,6 @@ Guava is a set of core libraries that includes new collection types (such as mul
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="Guava.ListenableFuture.targets" Pack="True" PackagePath="@(_TfmNuGetBuildFolders->'%(Identity)$(PackageId).targets')" />
-    <None Include="..\..\externals\guava-listenablefuture.jar" Pack="True" PackagePath="jar" />
     <None Include="..\..\External-Dependency-Info.txt" Pack="True" PackagePath="THIRD-PARTY-NOTICES.txt" />
   </ItemGroup>
 


### PR DESCRIPTION
### DO NOT MERGE THIS TO `main`, THIS WILL BE PUBLISHED OUT OF THE BRANCH

Creates a `9999.0.0` version of `Xamarin.Google.Guava.ListenableFuture` that does not include `guava-listenablefuture.jar`.  This version of the package will be the dependency for `Xamarin.Google.Guava`.  It will be delisted so that it does not show up for people adding an explicit reference to `Xamarin.Google.Guava.ListenableFuture`.

This mirrors the way Google/Maven have set this up:
https://mvnrepository.com/artifact/com.google.guava/listenablefuture

There are 3 scenarios we need to cover to ensure one (and only one) copy of `ListenableFuture.class` is included in an application.

- **Project (and dependencies) only references `Xamarin.Google.Guava.ListenableFuture`**
  - Project will reference the _listed_ version in NuGet (currently `1.0.0.7`)
  - `ListenableFuture.class` will be provided by `guava-listenablefuture.jar`
- **Project (and dependencies) only references `Xamarin.Google.Guava`**
  - `Xamarin.Google.Guava` will have a dependency on `Xamarin.Google.Guava.ListenableFuture` `9999.0` which does not include `guava-listenablefuture.jar`.
  - `ListenableFuture.class` will be provided by `guava.jar`
- **Project (and dependencies) references `Xamarin.Google.Guava.ListenableFuture` and `Xamarin.Google.Guava`**
  - `Xamarin.Google.Guava`'s dependency on `Xamarin.Google.Guava.ListenableFuture` `9999.0` will ensure this version is used.
  - `ListenableFuture.class` will be provided by `guava.jar`

Note `9999.0` package does not include `guava-listenablefuture.jar` or `Xamarin.Google.Guava.ListenableFuture.targets`.

![image](https://user-images.githubusercontent.com/179295/164075013-b8baac95-a8e8-4b95-b53c-ccd47aa22477.png)

Note that we _do_ provide managed bindings for `Xamarin.Google.Guava.ListenableFuture`, however we do not provide _any_ managed bindings for `Xamarin.Google.Guava`.  Thus the `9999.0` must still include the C# binding of `ListenableFuture` for applications that use it, since `Xamarin.Google.Guava` will not.

![image](https://user-images.githubusercontent.com/179295/164077049-c2ba3790-631d-4c34-9853-ffd4c98fea2a.png)
