### PR TITLE
[binderator] Add support for dependency versions declared in parent POMs.

### DIFF
--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Engine.cs
@@ -321,10 +321,10 @@ namespace AndroidBinderator
 				// Gather maven dependencies to try and map out nuget dependencies
 				foreach (var mavenDep in mavenProject.Dependencies)
 				{
+					FixDependency(config, mavenArtifact, mavenDep, mavenProject);
+
 					if (!ShouldIncludeDependency(config, mavenArtifact, mavenDep, exceptions))
 						continue;
-
-					mavenDep.Version = FixVersion(mavenDep.Version, mavenProject);
 
 					mavenDep.GroupId = mavenDep.GroupId.Replace ("${project.groupId}", mavenProject.GroupId);
 					mavenDep.Version = mavenDep.Version?.Replace ("${project.version}", mavenProject.Version);
@@ -485,14 +485,40 @@ namespace AndroidBinderator
 			return dest;
 		}
 
-		// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
-		// Fix them to be "1.0".
-		// https://github.com/NuGet/Home/issues/10342
-		static string FixVersion(string version, Project project)
+		static void FixDependency(BindingConfig config, MavenArtifactConfig mavenArtifact, Dependency dependency, Project project)
 		{
-			if (string.IsNullOrWhiteSpace(version))
-				return version;
+			// Handle Parent POM
+			if ((string.IsNullOrEmpty(dependency.Version) || string.IsNullOrEmpty(dependency.Scope)) && project.Parent != null) {
+				var parent_pom = GetParentPom(config, mavenArtifact, project.Parent);
+				var parent_dependency = parent_pom.FindParentDependency(dependency);
 
+				// Try to fish a version out of the parent POM
+				if (string.IsNullOrEmpty(dependency.Version))
+					dependency.Version = ReplaceVersionProperties(parent_pom, parent_dependency?.Version);
+
+				// Try to fish a scope out of the parent POM
+				if (string.IsNullOrEmpty(dependency.Scope))
+					dependency.Scope = parent_dependency?.Scope;
+			}
+
+			var version = dependency.Version;
+
+			if (string.IsNullOrWhiteSpace(version))
+				return;
+
+			version = ReplaceVersionProperties(project, version);
+
+			// VersionRange.Parse cannot handle single number versions that we sometimes see in Maven, like "1".
+			// Fix them to be "1.0".
+			// https://github.com/NuGet/Home/issues/10342
+			if (!version.Contains("."))
+				version += ".0";
+
+			dependency.Version = version;
+		}
+
+		static string ReplaceVersionProperties(Project project, string version)
+		{
 			// Handle versions with Properties, like:
 			// <properties>
 			//   <java.version>1.8</java.version>
@@ -505,15 +531,31 @@ namespace AndroidBinderator
 			//     <version>${gson.version}</version>
 			//   </dependency>
 			// </dependencies>
-			if (project?.Properties != null) {
-				foreach (var prop in project.Properties.Any)
-					version = version.Replace($"${{{prop.Name.LocalName}}}", prop.Value);
-			}
+			if (string.IsNullOrWhiteSpace(version) || project?.Properties == null)
+				return version;
 
-			if (!version.Contains("."))
-				version += ".0";
+			foreach (var prop in project.Properties.Any)
+				version = version.Replace ($"${{{prop.Name.LocalName}}}", prop.Value);
 
 			return version;
+		}
+
+		static Dictionary<string, Project> parent_poms = new Dictionary<string, Project>();
+
+		static Project GetParentPom(BindingConfig config, MavenArtifactConfig mavenArtifact, Parent parent)
+		{
+			var key = $"{parent.GroupId}.{parent.ArtifactId}-{parent.Version}";
+
+			if (parent_poms.TryGetValue(key, out var cached_pom))
+				return cached_pom;
+
+			var maven = MavenFactory.GetMavenRepository(config, mavenArtifact);
+			maven.Populate(parent.GroupId, parent.ArtifactId).Wait();
+			var pom = maven.GetProjectAsync(parent.GroupId, parent.ArtifactId, parent.Version).Result;
+
+			parent_poms.Add(key, pom);
+
+			return pom;
 		}
 	}
 }

--- a/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
+++ b/Util/Xamarin.AndroidBinderator/Xamarin.AndroidBinderator/Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using MavenNet.Models;
 
@@ -14,5 +15,11 @@ namespace AndroidBinderator
 		public static bool IsCompileDependency (this Dependency dependency) => string.IsNullOrWhiteSpace (dependency.Scope) || dependency.Scope.ToLowerInvariant ().Equals ("compile");
 
 		public static bool IsRuntimeDependency (this Dependency dependency) => dependency?.Scope != null && dependency.Scope.ToLowerInvariant ().Equals ("runtime");
+
+		public static Dependency FindParentDependency (this Project project, Dependency dependency)
+		{
+			return project.DependencyManagement?.Dependencies?.FirstOrDefault (
+				d => d.GroupAndArtifactId () == dependency.GroupAndArtifactId () && d.Classifier != "sources");
+		}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/pull/1291

Given a POM with dependencies that do not specify a version, like 
https://repo1.maven.org/maven2/com/google/guava/guava/31.1-android/guava-31.1-android.pom:

```xml
<dependency>
  <groupId>com.google.code.findbugs</groupId>
  <artifactId>jsr305</artifactId>
</dependency>
```

We need to see if the POM specifies a "parent POM":

```xml
<parent>
  <groupId>com.google.guava</groupId>
  <artifactId>guava-parent</artifactId>
  <version>31.1-android</version>
</parent>
```

If so, we need to download it and look at the `<dependencyManagement>` section to find the needed version of the dependency:
https://repo1.maven.org/maven2/com/google/guava/guava-parent/31.1-android/guava-parent-31.1-android.pom

```xml
<dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
    </dependency>
  </dependencyManagement>
</dependencies>
```

We can also sometimes find a `scope` here, which will help us to properly ignore `test` dependencies.