### PR TITLE
ArCore 1.31.0

### DIFF
--- a/Android/ARCore/build.cake
+++ b/Android/ARCore/build.cake
@@ -2,9 +2,9 @@
 
 var TARGET = Argument ("t", Argument ("target", "ci"));
 
-var NUGET_VERSION = "1.29.0";
+var NUGET_VERSION = "1.31.0";
 
-var AAR_VERSION = "1.29.0";
+var AAR_VERSION = "1.31.0";
 var AAR_URL = string.Format("https://dl.google.com/dl/android/maven2/com/google/ar/core/{0}/core-{0}.aar", AAR_VERSION);
 var OBJ_VERSION = "0.3.0";
 var OBJ_URL = string.Format("https://oss.sonatype.org/content/repositories/releases/de/javagl/obj/{0}/obj-{0}.jar", OBJ_VERSION);

--- a/Android/ARCore/cgmanifest.json
+++ b/Android/ARCore/cgmanifest.json
@@ -6,7 +6,7 @@
         "Maven": {
           "ArtifactId": "core",
           "GroupId": "com.google.ar",
-          "Version": "1.26.0",
+          "Version": "1.31.0",
           "NuGetId": "Xamarin.Google.ARCore"
         }
       }

--- a/Android/ARCore/source/Additions/Additions.cs
+++ b/Android/ARCore/source/Additions/Additions.cs
@@ -10,4 +10,13 @@ namespace Google.AR.Core
     public partial class InstantPlacementPoint : Google.AR.Core.ITrackable {}
     public partial class Plane : Google.AR.Core.ITrackable {}
     public partial class Point : Google.AR.Core.ITrackable {}
+
+    public partial class Earth
+    {
+        ~Earth()
+        {
+            InternalFinalize();
+        }
+    }
 }
+ 

--- a/Android/ARCore/source/Google.ARCore.csproj
+++ b/Android/ARCore/source/Google.ARCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
-    <ReleaseVersion>1.26.0</ReleaseVersion>
+    <ReleaseVersion>1.31.0</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Android/ARCore/source/Transforms/Metadata.xml
+++ b/Android/ARCore/source/Transforms/Metadata.xml
@@ -50,5 +50,18 @@
     -->
     <attr path="/api/package[@name='com.google.ar.core']/class[@name='InstallActivity']/method[@name='onDestroy' and count(parameter)=0]" name="managedOverride">override</attr>
     <attr path="/api/package[@name='com.google.ar.core']/class[@name='InstallActivity']/method[@name='onDestroy' and count(parameter)=0]" name="visibility">protected</attr>
+
+    <!--
+	Earth class implemented a Java Finalizer. Implement a C# Destructor and call the finalize method.
+    The C# Destructor is in the partial class under the Addition folder.
+	-->
+    <attr path="/api/package[@name='com.google.ar.core']/class[@name='Earth']/method[@name='finalize' and count(parameter)=0]" name="managedName">InternalFinalize</attr>
+    <attr path="/api/package[@name='com.google.ar.core']/class[@name='Earth']/method[@name='finalize' and count(parameter)=0]" name="visibility">internal</attr>
     
+    <!--
+	Duplicate method with a different return value
+    // Metadata.xml XPath method reference: path="/api/package[@name='com.google.ar.core']/class[@name='Earth']/method[@name='getAnchors' and count(parameter)=0]"
+	-->
+    <remove-node path="/api/package[@name='com.google.ar.core']/class[@name='TrackableBase']/method[@name='getAnchors' and count(parameter)=0]" />
+
 </metadata>


### PR DESCRIPTION
Updated acore binding to include changes from 1.31

https://github.com/google-ar/arcore-android-sdk/releases/tag/v1.31.0

```
The Depth API function calls have changed:
Frame.acquireDepthImage() has been deprecated in favor of Frame.acquireDepthImage16Bits().
Frame.acquireRawDepthImage() has been deprecated in favor of Frame.acquireRawDepthImage16Bits().
The output image formats for both calls have changed from
android.graphics.ImageFormat.DEPTH16 to
android.hardware.HardwareBuffer.D_16.
Depth is still represented as a 16-bit integer in units of
millimeters, but now all 16-bits are used to represent depth, allowing
for a maximum expressible range of 65535mm (previously 8191mm).
```
