### PR TITLE
[ci] Add custom build steps that run after the API Diff.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -10,6 +10,7 @@ parameters:
   initSteps: []                                             # any steps to run before .NET global tools are installed
   preBuildSteps: []                                         # any steps that need to run just before the main compilation starts
   postBuildSteps: []                                        # any steps that need to run just after the main compilation ends
+  postDiffBuildSteps: []                                    # any steps that need to run after the API Diff ends
   masterBranchName: 'main'                                  # the "master" branch that should be used - can be something other than "master"
   installAppleCertificates: 'true'                          # whether or not to install the Apple certificates and provisioning profiles
   submodules: false                                         # whether or not to check out submodules
@@ -360,6 +361,8 @@ jobs:
         inputs:
           PathToPublish: output
           ArtifactName: output-$(System.JobName)${{ parameters.publishOutputSuffix }}
+      # custom post-api-diff steps
+      - ${{ parameters.postDiffBuildSteps }}
       # run any required checks
       - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
         - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
In AndroidX https://github.com/xamarin/AndroidX/pull/558, we added a new check that ensure all new namespaces are approved.  This `postBuildStep` runs correctly, however it runs before the API Diff generator.

In the case where this new check fails and aborts the build, it would be nice to have access to the API-diffs to see the new API to review.

This PR adds a new `postDiffBuildSteps`  section where custom steps can be run after the API Diff is run.

Note: `main` for this repository seems to be broken.  This PR only affects `build.yml`, which is not used by this repository's CI.