### PR TITLE
Allow Xamarin.Build.Download to optional bypass validate ID 

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
@@ -33,64 +33,57 @@ namespace Xamarin.Build.Download
 			var results = new List<XamarinBuildDownload> ();
 
 			foreach (var item in items) {
-                try
-                {
-					var xbd = new XamarinBuildDownload();
+				var xbd = new XamarinBuildDownload();
 
-					xbd.Id = item.ItemSpec;
-					if (!ValidateId(xbd.Id, this.BypassValidation))
-					{
-						Log.LogCodedError(ErrorCodes.XbdInvalidItemId, "Invalid item ID {0}", xbd.Id);
-						continue;
-					}
-					xbd.Url = item.GetMetadata("Url");
-					if (string.IsNullOrEmpty(xbd.Url))
-					{
-						Log.LogCodedError(ErrorCodes.XbdInvalidUrl, "Missing required Url metadata on item {0}", item.ItemSpec);
-						continue;
-					}
-					xbd.Sha256 = item.GetMetadata("Sha256");
-					xbd.Kind = GetKind(xbd.Url, item.GetMetadata("Kind"));
-					if (xbd.Kind == ArchiveKind.Unknown)
-					{
-						//TODO we may be able to determine the kind from the server response
-						continue;
-					}
-					if (!EnsureSecureUrl(item, xbd.Url, allowUnsecureUrls))
-					{
-						continue;
-					}
-
-					xbd.CustomErrorCode = item.GetMetadata("CustomErrorCode");
-					xbd.CustomErrorMessage = item.GetMetadata("CustomErrorMessage");
-
-					// By default, use the kind (tgz or zip) as the file extension for the cache file
-					var cacheFileExt = xbd.Kind.ToString().ToLower();
-
-					// If we have an uncompressed file specified (move file instead of decompressing it)
-					if (xbd.Kind == ArchiveKind.Uncompressed)
-					{
-						// Get the filename
-						xbd.ToFile = item.GetMetadata("ToFile");
-						// If we have a tofile set, try and grab its extension
-						if (!string.IsNullOrEmpty(xbd.ToFile))
-							cacheFileExt = Path.GetExtension(xbd.ToFile)?.ToLower() ?? string.Empty;
-					}
-
-					xbd.CacheFile = Path.Combine(CacheDir, item.ItemSpec.TrimEnd('.') + "." + cacheFileExt.TrimStart('.'));
-					xbd.DestinationDir = Path.GetFullPath(Path.Combine(CacheDir, item.ItemSpec));
-
-					int lockTimeout = 60;
-					if (int.TryParse(item.GetMetadata("ExclusiveLockTimeout"), out lockTimeout))
-						xbd.ExclusiveLockTimeout = lockTimeout;
-
-					results.Add(xbd);
+				xbd.Id = item.ItemSpec;
+				if (!ValidateId(xbd.Id, this.BypassValidation))
+				{
+					Log.LogCodedError(ErrorCodes.XbdInvalidItemId, "Invalid item ID {0}", xbd.Id);
+					continue;
 				}
-				catch(Exception ex)
-                {
-					Log.LogErrorFromException(ex);
-                }
-				
+				xbd.Url = item.GetMetadata("Url");
+				if (string.IsNullOrEmpty(xbd.Url))
+				{
+					Log.LogCodedError(ErrorCodes.XbdInvalidUrl, "Missing required Url metadata on item {0}", item.ItemSpec);
+					continue;
+				}
+				xbd.Sha256 = item.GetMetadata("Sha256");
+				xbd.Kind = GetKind(xbd.Url, item.GetMetadata("Kind"));
+				if (xbd.Kind == ArchiveKind.Unknown)
+				{
+					//TODO we may be able to determine the kind from the server response
+					continue;
+				}
+				if (!EnsureSecureUrl(item, xbd.Url, allowUnsecureUrls))
+				{
+					continue;
+				}
+
+				xbd.CustomErrorCode = item.GetMetadata("CustomErrorCode");
+				xbd.CustomErrorMessage = item.GetMetadata("CustomErrorMessage");
+
+				// By default, use the kind (tgz or zip) as the file extension for the cache file
+				var cacheFileExt = xbd.Kind.ToString().ToLower();
+
+				// If we have an uncompressed file specified (move file instead of decompressing it)
+				if (xbd.Kind == ArchiveKind.Uncompressed)
+				{
+					// Get the filename
+					xbd.ToFile = item.GetMetadata("ToFile");
+					// If we have a tofile set, try and grab its extension
+					if (!string.IsNullOrEmpty(xbd.ToFile))
+						cacheFileExt = Path.GetExtension(xbd.ToFile)?.ToLower() ?? string.Empty;
+				}
+
+				xbd.CacheFile = Path.Combine(CacheDir, item.ItemSpec.TrimEnd('.') + "." + cacheFileExt.TrimStart('.'));
+				xbd.DestinationDir = Path.GetFullPath(Path.Combine(CacheDir, item.ItemSpec));
+
+				int lockTimeout = 60;
+				if (int.TryParse(item.GetMetadata("ExclusiveLockTimeout"), out lockTimeout))
+					xbd.ExclusiveLockTimeout = lockTimeout;
+
+				results.Add(xbd);
+
 			}
 
 			// Deduplicate possible results by their Id which should be unique always for the given archive

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets
@@ -26,6 +26,10 @@
 		<_XamarinBuildDownloadIsAndroid>false</_XamarinBuildDownloadIsAndroid>
 	</PropertyGroup>
 	
+	<PropertyGroup Condition="'$(XamarinBuildDownloadBypassValidation)' == 'true'">
+		<BypassValidation>true</BypassValidation>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<CleanDependsOn>
 			$(CleanDependsOn);
@@ -57,6 +61,7 @@
 			User7ZipPath="$(XamarinBuildDownloadUser7ZipPath)"
 			VsInstallRoot="$(VsInstallRoot)"
 			IsAndroid="$(_XamarinBuildDownloadIsAndroid)"
+			BypassValidation="$(BypassValidation)"
 			/>
 	</Target>
 
@@ -67,6 +72,7 @@
 			Parts="@(XamarinBuildDownloadPartialZip)"
 			CacheDirectory="$(XamarinBuildDownloadDir)"
 			IsAndroid="$(_XamarinBuildDownloadIsAndroid)"
+			BypassValidation="$(BypassValidation)"
 			/>
 	</Target>
 
@@ -115,7 +121,8 @@
 			Archives="@(XamarinBuildDownload)"
 			PartialZipDownloads="@(XamarinBuildDownloadPartialZip)"
 			DestinationBase="$(XamarinBuildDownloadDir)"
-			CacheDirectory="$(XamarinBuildDownloadDir)">
+			CacheDirectory="$(XamarinBuildDownloadDir)"
+			BypassValidation="$(BypassValidation)">
 			<Output TaskParameter="ArchivesToDownload" ItemName="XamarinBuildDownloadItemToDownload" />
 		</XamarinBuildGetArchivesToDownload>
 	</Target>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinBuildGetArchivesToDownload.cs
@@ -20,13 +20,15 @@ namespace Xamarin.Build.Download
 
 		public bool AllowUnsecureUrls { get; set; }
 
+		public bool BypassValidation { get; set; }
+
 		DownloadUtils downloadUtils;
 
 		public override bool Execute ()
 		{
 			var results = new List<ITaskItem> ();
 
-			downloadUtils = new DownloadUtils (this, CacheDirectory);
+			downloadUtils = new DownloadUtils (this, CacheDirectory, BypassValidation);
 
 			var items = downloadUtils.ParseDownloadItems (Archives, AllowUnsecureUrls);
 

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -32,12 +32,13 @@ namespace Xamarin.Build.Download
 
 		public bool IsAndroid { get; set; }
 
+		public bool BypassValidation { get; set; }
+
 		DownloadUtils downloadUtils;
 
 		public override bool Execute ()
 		{
-			downloadUtils = new DownloadUtils (this, CacheDirectory);
-
+			downloadUtils = new DownloadUtils (this, CacheDirectory, BypassValidation);
 			Task.Run (async () => {
 				try {
 					var items = downloadUtils.ParseDownloadItems (Archives, AllowUnsecureUrls);

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadPartialZips.cs
@@ -20,6 +20,8 @@ namespace Xamarin.Build.Download
 		public bool AllowUnsecureUrls { get; set; }
 
 		public bool IsAndroid { get; set; }
+		public bool BypassValidation { get; set; }
+
 
 		HttpClient http;
 
@@ -35,7 +37,7 @@ namespace Xamarin.Build.Download
 					http = new HttpClient ();
 
 					var cacheDir = DownloadUtils.GetCacheDir (CacheDirectory);
-					var downloadUtils = new DownloadUtils (this, cacheDir);
+					var downloadUtils = new DownloadUtils (this, cacheDir, BypassValidation);
 
 					parts = downloadUtils.ParsePartialZipDownloadItems (Parts, AllowUnsecureUrls);
 


### PR DESCRIPTION
Since invalid item id always occurs if the library is beta version, this update allow us bypass the validation so Xamarin.Build.Download will not block the build.

Issue related: 
#1293 
[Invalid item ID image-1.0.0-beta1](https://github.com/xamarin/GooglePlayServicesComponents/issues/617)
[Invalid item ID image-1.0.0-beta1](https://github.com/xamarin/GooglePlayServicesComponents/issues/621)


Accept property XamarinBuildDownloadBypassValidation from .csproj to bypass validation on downloading packages by adding these lines in csproj.

```
<Project>
....
	<Target Name="SetXamarinBuildDownloadBypassValidation" DependsOnTargets="BeforeBuild">
		<PropertyGroup>
			<XamarinBuildDownloadBypassValidation>true</XamarinBuildDownloadBypassValidation>
		</PropertyGroup>
	</Target>
....
</Project>
```

This will ignore error ErrorCodes.XbdInvalidItemId and download the beta package.