### PR TITLE
[Xamarin.Build.Download] Support pre-release package ids.

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download.Tests/Xamarin.Build.Download.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/DownloadUtils.cs
@@ -197,9 +197,9 @@ namespace Xamarin.Build.Download
 		//VERSION:
 		// * components separated by periods
 		// * each component must consist of letters and numbers
-		//
+		// * optional hyphen and pre-release id (eg: '-beta01')
 		static readonly Regex idRegex = new Regex (
-			@"[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+-[A-Za-z\d]+(\.[A-Za-z\d]+)*(/[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+)?"
+			@"[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+-[A-Za-z\d]+(\.[A-Za-z\d]+)*(/[A-Za-z]+[A-Za-z\d\._]*[A-Za-z\d]+)?(-\w*)?"
 			,
 			RegexOptions.Compiled
 		);

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Xamarin.Build.Download</PackageId>
     <Title>Xamarin Build-time Download Support</Title>
-    <PackageVersion>0.11.2</PackageVersion>
+    <PackageVersion>0.11.3</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>


### PR DESCRIPTION
Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/617
Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/621
Context: https://github.com/xamarin/GooglePlayServicesComponents/issues/624

GPS binds 2 pre-release packages:
- Xamarin.Google.Android.ODML.Image 1.0.0-beta1
- Xamarin.GooglePlayServices.MLKit.LanguageId  117.0.0.1-beta1

Attempting to consume these results in XBD errors because the pre-release specifier is rejected:

```
error XBD020: Invalid item ID image-1.0.0-beta1
```

We need to expand our version regex to support pre-release specifiers so these can be downloaded.