### PR TITLE
[ci] Changes to fix CI.

### DIFF
--- a/.ci/build-manifest.cake
+++ b/.ci/build-manifest.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.XCode&version=4.2.0
+#addin nuget:?package=Cake.XCode&version=5.0.0
 #addin nuget:?package=Cake.Yaml&version=3.1.0&loadDependencies=true
 #addin nuget:?package=Cake.Json&version=4.0.0&loadDependencies=true
 #addin nuget:?package=Xamarin.Nuget.Validator&version=1.1.1
@@ -416,14 +416,6 @@ public class BuildGroup {
 	public bool BuildOnLinux => LinuxBuildTargets?.Any () == true;
 
 	public override string ToString () => Name;
-}
-
-bool IsRunningOnMacOs () {
-	return System.Environment.OSVersion.Platform == PlatformID.MacOSX || MacPlatformDetector.IsMac.Value;
-}
-
-bool IsRunningOnLinux () {
-	return IsRunningOnUnix () && !IsRunningOnMacOs ();
 }
 
 internal static class MacPlatformDetector {

--- a/.ci/build.steps.v1.yml
+++ b/.ci/build.steps.v1.yml
@@ -28,7 +28,7 @@ parameters:
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
   windowsImageOverride: ''                                  # used to access 1ES hardened images: name of ImageOverride demand to use such as AzurePipelinesWindows2022compliant when windowsAgentPoolName set to the AzurePipelines-EO pool
   mono: 'Latest'                                            # the version of mono to use
-  xcode: '13.3.1'                                           # the version of Xcode to use
+  xcode: '13.2.1'                                           # the version of Xcode to use
   dotnet: '6.0.300'                                         # the version of .NET Core to use
   dotnetStable: '6.0.300'                                   # the stable version of .NET Core to use
   cake: '2.2.0'                                             # the version of Cake to use
@@ -231,7 +231,7 @@ steps:
           --gitcommit="$(Build.SourceVersion)" `
           --gitbranch="$(Build.SourceBranch)" `
           --forcebuild="$force" `
-          --names="$names" `
+          --names "$names" `
           --targets="$targets" `
           --copyoutputtoroot=true `
           --configuration="${{ parameters.configuration }}" `
@@ -260,7 +260,7 @@ steps:
           --gitcommit="$(Build.SourceVersion)" `
           --gitbranch="$(Build.SourceBranch)" `
           --forcebuild="$force" `
-          --names="$names" `
+          --names "$names" `
           --targets="$targets" `
           --copyoutputtoroot=true `
           --configuration="${{ parameters.configuration }}" `

--- a/.ci/build.v1.yml
+++ b/.ci/build.v1.yml
@@ -32,7 +32,7 @@ parameters:
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
   windowsImageOverride: ''                                  # used to access 1ES hardened images: name of ImageOverride demand to use such as AzurePipelinesWindows2022compliant when windowsAgentPoolName set to the AzurePipelines-EO pool
   mono: 'Latest'                                            # the version of mono to use
-  xcode: '13.3.1'                                           # the version of Xcode to use
+  xcode: '13.2.1'                                           # the version of Xcode to use
   dotnet: '6.0.300'                                         # the version of .NET Core to use
   dotnetStable: '6.0.300'                                   # the stable version of .NET Core to use
   cake: '2.2.0'                                             # the version of Cake to use

--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -31,7 +31,7 @@ parameters:
                                                             # macOS-11 required for XCode 13.1
   windowsImage: 'windows-latest'                            # the name of the Windows VM image
   mono: 'Latest'                                            # the version of mono to use
-  xcode: '13.3.1'                                             # the version of Xcode to use
+  xcode: '13.2.1'                                             # the version of Xcode to use
   dotnet: '6.0.300'                                         # the version of .NET Core to use
   dotnetStable: '6.0.300'                                   # the stable version of .NET Core to use
   cake: '2.2.0'                                             # the version of Cake to use
@@ -257,7 +257,7 @@ jobs:
               --gitcommit="$(Build.SourceVersion)" `
               --gitbranch="$(Build.SourceBranch)" `
               --forcebuild="$force" `
-              --names="$names" `
+              --names "$names" `
               --targets="$targets" `
               --copyoutputtoroot=true `
               --configuration="${{ parameters.configuration }}" `
@@ -286,7 +286,7 @@ jobs:
               --gitcommit="$(Build.SourceVersion)" `
               --gitbranch="$(Build.SourceBranch)" `
               --forcebuild="$force" `
-              --names="$names" `
+              --names "$names" `
               --targets="$targets" `
               --copyoutputtoroot=true `
               --configuration="${{ parameters.configuration }}" `

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
       windowsImage: ''
       windowsImageOverride: AzurePipelinesWindows2019compliant
 
-      xcode: 13.3.1
+      xcode: 13.2.1
       buildType: 'manifest'
 
       linuxAgentPoolName: AzurePipelines-EO


### PR DESCRIPTION
Author's note: I know very little about Cake or this repository's CI, so please review thoroughly!  😁 

Changes to fix the currently broken XC CI:

- Updating Cake had a [breaking change](https://cakebuild.net/docs/getting-started/upgrade#cake-cli-updates) that no longer allows empty CLI arguments to be passed with `--foo=""`.  It is now required to omit the equals sign.

- Errors when trying to run `build-manifest.cake` fixed by removing methods 🤷‍♂️:
```
C:/code/XamarinComponents/.ci/build-manifest.cake(421,6): error CS0111: Type 'Submission#0' already defines a member called 'IsRunningOnMacOs' with the same parameter types
C:/code/XamarinComponents/.ci/build-manifest.cake(425,6): error CS0111: Type 'Submission#0' already defines a member called 'IsRunningOnLinux' with the same parameter types
```

- Error when trying to run `build-manifest.cake` fixed by updating `Cake.XCode`:
```
C:/code/XamarinComponents/.ci/build-manifest.cake(234,4): error CS0103: The name 'CocoaPodRepoUpdate' does not exist in the current context
```

- Revert requested XCode to `13.2.1`.  We are building on `macos-11`, which [does not support](https://developer.apple.com/support/xcode) XCode `13.3.1`.

Note this PR will show as failed because CI is set up to use the `.ci` files from `main`.  Here is a build that actually uses the files from the PR: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6282119.