### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/Android/ARCore/cgmanifest.json
+++ b/Android/ARCore/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/AndroidEasingFunctions/cgmanifest.json
+++ b/Android/AndroidEasingFunctions/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/AudioSwitch/cgmanifest.json
+++ b/Android/AudioSwitch/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/CheckerFramework/cgmanifest.json
+++ b/Android/CheckerFramework/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",
@@ -10,7 +11,7 @@
           "NuGetId": "Xamarin.CheckerFramework.Checker"
         }
       }
-    },
+    }
   ],
   "Version": 1
 }

--- a/Android/Coil/cgmanifest.json
+++ b/Android/Coil/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/CoilBase/cgmanifest.json
+++ b/Android/CoilBase/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/ConstraintLayout/cgmanifest.json
+++ b/Android/ConstraintLayout/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/DesugarJDKLibs/cgmanifest.json
+++ b/Android/DesugarJDKLibs/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/Glide/cgmanifest.json
+++ b/Android/Glide/cgmanifest.json
@@ -1,45 +1,46 @@
 {
-    "Registrations":[ 
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "glide",
-            "GroupId": "com.github.bumptech.glide",
-            "Version": "4.12.0"
-          }
-        }
-      },
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "gifdecoder",
-            "GroupId": "com.github.bumptech.glide",
-            "Version": "4.12.0"
-          }
-        }
-      },
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "disklrucache",
-            "GroupId": "com.github.bumptech.glide",
-            "Version": "4.12.0"
-          }
-        }
-      },
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "recyclerview-integration",
-            "GroupId": "com.github.bumptech.glide",
-            "Version": "4.12.0"
-          }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "glide",
+          "GroupId": "com.github.bumptech.glide",
+          "Version": "4.12.0"
         }
       }
-    ],
-    "Version": 1
-  }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "gifdecoder",
+          "GroupId": "com.github.bumptech.glide",
+          "Version": "4.12.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "disklrucache",
+          "GroupId": "com.github.bumptech.glide",
+          "Version": "4.12.0"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "recyclerview-integration",
+          "GroupId": "com.github.bumptech.glide",
+          "Version": "4.12.0"
+        }
+      }
+    }
+  ],
+  "Version": 1
+}

--- a/Android/Google.Android.DataTransport/cgmanifest.json
+++ b/Android/Google.Android.DataTransport/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",
@@ -9,7 +10,9 @@
           "Version": "3.0.0",
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportApi"
         }
-      },
+      }
+    },
+    {
       "Component": {
         "Type": "Maven",
         "Maven": {
@@ -18,7 +21,9 @@
           "Version": "3.0.0",
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct"
         }
-      },
+      }
+    },
+    {
       "Component": {
         "Type": "Maven",
         "Maven": {
@@ -28,7 +33,7 @@
           "NuGetId": "Xamarin.Google.Android.DataTransport.TransportRuntime"
         }
       }
-    },
+    }
   ],
   "Version": 1
 }

--- a/Android/Google.LibPhoneNumber/cgmanifest.json
+++ b/Android/Google.LibPhoneNumber/cgmanifest.json
@@ -1,16 +1,17 @@
 {
-    "Registrations": [
-        {
-            "Component": {
-                "Type": "Maven",
-                "Maven": {
-                    "ArtifactId": "libphonenumber",
-                    "GroupId": "com.googlecode.libphonenumber",
-                    "Version": "8.10.23",
-                    "NuGetId": "Xamarin.Google.LibPhoneNumber"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "libphonenumber",
+          "GroupId": "com.googlecode.libphonenumber",
+          "Version": "8.10.23",
+          "NuGetId": "Xamarin.Google.LibPhoneNumber"
         }
-    ],
-    "Version": 1
+      }
+    }
+  ],
+  "Version": 1
 }

--- a/Android/Google.Play.Core/cgmanifest.json
+++ b/Android/Google.Play.Core/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/GoogleAndroidVending/cgmanifest.json
+++ b/Android/GoogleAndroidVending/cgmanifest.json
@@ -1,27 +1,28 @@
 {
-	"Registrations": [
-		{
-			"component": {
-				"type": "git",
-				"git": {
-					"name": "play-licensing",
-					"repositoryUrl": "https://github.com/google/play-licensing.git",
-					"commitHash": "89ebdfcf52562018ff4c366055f0e35393919763"
-                },
-                "nugetId": "Xamarin.Google.Android.Vending.Licensing"
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "play-licensing",
+          "repositoryUrl": "https://github.com/google/play-licensing.git",
+          "commitHash": "89ebdfcf52562018ff4c366055f0e35393919763"
         },
-        {
-            "component": {
-				"type": "git",
-				"git": {
-					"name": "play-apk-expansion",
-					"repositoryUrl": "https://github.com/google/play-apk-expansion.git",
-					"commitHash": "9ecf54e5ce7c5a74a2eeedcec4d940ea52b16f0e"
-                },
-                "nugetId": "Xamarin.Google.Android.Vending.Expansion.Downloader"
-			}
-		}
-	],
-	"Version": 1
+        "nugetId": "Xamarin.Google.Android.Vending.Licensing"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "play-apk-expansion",
+          "repositoryUrl": "https://github.com/google/play-apk-expansion.git",
+          "commitHash": "9ecf54e5ce7c5a74a2eeedcec4d940ea52b16f0e"
+        },
+        "nugetId": "Xamarin.Google.Android.Vending.Expansion.Downloader"
+      }
+    }
+  ],
+  "Version": 1
 }

--- a/Android/GoogleAutoValue/cgmanifest.json
+++ b/Android/GoogleAutoValue/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/GoogleBillingClient/cgmanifest.json
+++ b/Android/GoogleBillingClient/cgmanifest.json
@@ -1,15 +1,16 @@
 {
-    "Registrations":[ 
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "billing",
-            "GroupId": "com.android.billingclient",
-            "Version": "4.0.0"
-          }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "billing",
+          "GroupId": "com.android.billingclient",
+          "Version": "4.0.0"
         }
       }
-    ],
-    "Version": 1
-  }
+    }
+  ],
+  "Version": 1
+}

--- a/Android/GoogleDagger/cgmanifest.json
+++ b/Android/GoogleDagger/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/GoogleGson/cgmanifest.json
+++ b/Android/GoogleGson/cgmanifest.json
@@ -1,15 +1,16 @@
 {
-    "Registrations":[ 
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "gson",
-            "GroupId": "com.google.code.gson",
-            "Version": "2.8.9"
-          }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "gson",
+          "GroupId": "com.google.code.gson",
+          "Version": "2.8.9"
         }
       }
-    ],
-    "Version": 1
-  }
+    }
+  ],
+  "Version": 1
+}

--- a/Android/GooglePlaces/cgmanifest.json
+++ b/Android/GooglePlaces/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/GoogleZXing/cgmanifest.json
+++ b/Android/GoogleZXing/cgmanifest.json
@@ -1,16 +1,17 @@
 {
-    "Registrations": [
-      {
-        "Component": {
-          "Type": "Maven",
-          "Maven": {
-            "ArtifactId": "core",
-            "GroupId": "com.google.zxing",
-            "Version": "3.3.3",
-            "NuGetId": "Xamarin.Google.ZXing.Core"
-          }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "core",
+          "GroupId": "com.google.zxing",
+          "Version": "3.3.3",
+          "NuGetId": "Xamarin.Google.ZXing.Core"
         }
       }
-    ],
-    "Version": 1
-  }
+    }
+  ],
+  "Version": 1
+}

--- a/Android/Guava/cgmanifest.json
+++ b/Android/Guava/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/Io.OpenCensus/cgmanifest.json
+++ b/Android/Io.OpenCensus/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/Io.PerfMark/cgmanifest.json
+++ b/Android/Io.PerfMark/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",
@@ -10,7 +11,7 @@
           "NuGetId": "Xamarin.Io.PerfMark.PerfMarkApi"
         }
       }
-    },
+    }
   ],
   "Version": 1
 }

--- a/Android/JakeWhartonPicasso2OkHttp3Downloader/cgmanifest.json
+++ b/Android/JakeWhartonPicasso2OkHttp3Downloader/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/JavaxInject/cgmanifest.json
+++ b/Android/JavaxInject/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/Kotlin/cgmanifest.json
+++ b/Android/Kotlin/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/KotlinXCoroutines/cgmanifest.json
+++ b/Android/KotlinXCoroutines/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/PdfViewPager/cgmanifest.json
+++ b/Android/PdfViewPager/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/Protobuf.JavaLite/cgmanifest.json
+++ b/Android/Protobuf.JavaLite/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/ReLinker/cgmanifest.json
+++ b/Android/ReLinker/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/ReactiveStreams/cgmanifest.json
+++ b/Android/ReactiveStreams/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/ReactiveX/cgmanifest.json
+++ b/Android/ReactiveX/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/RecyclerView.FastScroll/cgmanifest.json
+++ b/Android/RecyclerView.FastScroll/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SceneForm/cgmanifest.json
+++ b/Android/SceneForm/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SignalRJavaClient/cgmanifest.json
+++ b/Android/SignalRJavaClient/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareAndroidTimesSquare/cgmanifest.json
+++ b/Android/SquareAndroidTimesSquare/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareMoshi/cgmanifest.json
+++ b/Android/SquareMoshi/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareMoshiAdapters/cgmanifest.json
+++ b/Android/SquareMoshiAdapters/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareMoshiKotlin/cgmanifest.json
+++ b/Android/SquareMoshiKotlin/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp/cgmanifest.json
+++ b/Android/SquareOkHttp/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3-v3/cgmanifest.json
+++ b/Android/SquareOkHttp3-v3/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3/cgmanifest.json
+++ b/Android/SquareOkHttp3/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3LoggingInterceptor/cgmanifest.json
+++ b/Android/SquareOkHttp3LoggingInterceptor/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3UrlConnection-v3/cgmanifest.json
+++ b/Android/SquareOkHttp3UrlConnection-v3/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3UrlConnection/cgmanifest.json
+++ b/Android/SquareOkHttp3UrlConnection/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttp3WS/cgmanifest.json
+++ b/Android/SquareOkHttp3WS/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttpUrlConnection/cgmanifest.json
+++ b/Android/SquareOkHttpUrlConnection/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkHttpWS/cgmanifest.json
+++ b/Android/SquareOkHttpWS/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareOkIO/cgmanifest.json
+++ b/Android/SquareOkIO/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquarePicasso/cgmanifest.json
+++ b/Android/SquarePicasso/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquarePollexor/cgmanifest.json
+++ b/Android/SquarePollexor/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit/cgmanifest.json
+++ b/Android/SquareRetrofit/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit2/cgmanifest.json
+++ b/Android/SquareRetrofit2/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit2AdapterRxJava2/cgmanifest.json
+++ b/Android/SquareRetrofit2AdapterRxJava2/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit2ConverterGson/cgmanifest.json
+++ b/Android/SquareRetrofit2ConverterGson/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit2ConverterMoshi/cgmanifest.json
+++ b/Android/SquareRetrofit2ConverterMoshi/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareRetrofit2ConverterScalars/cgmanifest.json
+++ b/Android/SquareRetrofit2ConverterScalars/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/SquareSeismic/cgmanifest.json
+++ b/Android/SquareSeismic/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/Android/StickyListHeaders/cgmanifest.json
+++ b/Android/StickyListHeaders/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/SurfaceDuo/cgmanifest.json
+++ b/Android/SurfaceDuo/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/ThreeTenAbp/cgmanifest.json
+++ b/Android/ThreeTenAbp/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/TokenAutoComplete/cgmanifest.json
+++ b/Android/TokenAutoComplete/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/Android/Volley/cgmanifest.json
+++ b/Android/Volley/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/XPlat/AzureMessaging/cgmanifest.json
+++ b/XPlat/AzureMessaging/cgmanifest.json
@@ -1,26 +1,27 @@
 {
-    "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
-      "component": { 
-       "type": "git", 
-       "git": { 
-         "repositoryUrl": "https://github.com/Azure/azure-notificationhubs-ios.git", 
-         "commitHash": "e4cf0b765f88448ee0d1298a34f1ef73764ee54e" 
-         },
-        "nugetId" : "Xamarin.Azure.NotificationHubs.iOS"
-       }
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/Azure/azure-notificationhubs-ios.git",
+          "commitHash": "e4cf0b765f88448ee0d1298a34f1ef73764ee54e"
+        },
+        "nugetId": "Xamarin.Azure.NotificationHubs.iOS"
+      }
     },
     {
       "Component": {
-         "Type": "Maven",
-         "Maven": {
-           "ArtifactId": "notification-hubs-android-sdk",
-           "GroupId": "com.microsoft.azure",
-           "Version": "1.0.0-preview2"
-         },
-         "nugetId" : "Xamarin.Azure.NotificationHubs.Android"
-       }
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "notification-hubs-android-sdk",
+          "GroupId": "com.microsoft.azure",
+          "Version": "1.0.0-preview2"
+        },
+        "nugetId": "Xamarin.Azure.NotificationHubs.Android"
+      }
     }
- ],
- "Version": 1
+  ],
+  "Version": 1
 }

--- a/XPlat/Chromium.CroNet/cgmanifest.json
+++ b/XPlat/Chromium.CroNet/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",
@@ -9,7 +10,9 @@
           "Version": "72.3626.96",
           "NuGetId": "Xamarin.Chromium.CroNet.Api"
         }
-      },
+      }
+    },
+    {
       "Component": {
         "Type": "Maven",
         "Maven": {
@@ -18,7 +21,9 @@
           "Version": "72.3626.96",
           "NuGetId": "Xamarin.Chromium.CroNet.Common"
         }
-      },
+      }
+    },
+    {
       "Component": {
         "Type": "Maven",
         "Maven": {
@@ -27,7 +32,9 @@
           "Version": "72.3626.96",
           "NuGetId": "Xamarin.Chromium.CroNet.Embedded"
         }
-      },
+      }
+    },
+    {
       "Component": {
         "Type": "Maven",
         "Maven": {
@@ -37,7 +44,7 @@
           "NuGetId": "Xamarin.Chromium.CroNet.FallBack"
         }
       }
-    },
+    }
   ],
   "Version": 1
 }

--- a/XPlat/Google.Grpc/cgmanifest.json
+++ b/XPlat/Google.Grpc/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",
@@ -76,7 +77,7 @@
           "NuGetId": "Xamarin.Grpc.Api"
         }
       }
-    },
+    }
   ],
   "Version": 1
 }

--- a/XPlat/OfficeUIFabric/Android/cgmanifest.json
+++ b/XPlat/OfficeUIFabric/Android/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/XPlat/TensorFlow.Lite/cgmanifest.json
+++ b/XPlat/TensorFlow.Lite/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "Maven",

--- a/iOS/MWPhotoBrowser/cgmanifest.json
+++ b/iOS/MWPhotoBrowser/cgmanifest.json
@@ -1,14 +1,15 @@
 {
-  "Registrations":[
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "Component": {
         "Type": "git",
         "Git": {
-           "CommitHash": "66ddd73859978a9c24c6ce014634f3bde351e917",
-           "RepositoryUrl": "https://github.com/mwaterfall/MWPhotoBrowser.git",
-           "NugetId": "Xamarin.MWPhotoBrowser"
-          }
-     }
+          "CommitHash": "66ddd73859978a9c24c6ce014634f3bde351e917",
+          "RepositoryUrl": "https://github.com/mwaterfall/MWPhotoBrowser.git",
+          "NugetId": "Xamarin.MWPhotoBrowser"
+        }
+      }
     }
   ],
   "Version": 1

--- a/iOS/SwiftRuntimeSupport/cgmanifest.json
+++ b/iOS/SwiftRuntimeSupport/cgmanifest.json
@@ -1,5 +1,6 @@
 {
-  "Registrations":[ 
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
     {
       "component": {
         "type": "git",


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.