### PR TITLE
[Xamarin.Build.Download] Guard against race condition when multiple processes are downloading same artifact.

### DIFF
--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Xamarin.Build.Download</PackageId>
     <Title>Xamarin Build-time Download Support</Title>
-    <PackageVersion>0.11.3</PackageVersion>
+    <PackageVersion>0.11.4</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865061</PackageProjectUrl>

--- a/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
+++ b/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs
@@ -109,6 +109,7 @@ namespace Xamarin.Build.Download
 				} catch { }
 			}
 
+			LogMessage ("Hash mismatch for file: " + fileToHash, MessageImportance.High);
 			return false;
 		}
 
@@ -151,6 +152,10 @@ namespace Xamarin.Build.Download
 					LogMessage ("Timed out waiting for an exclusive file lock on: " + lockFile, MessageImportance.High);
 					return false;
 				}
+
+				// Check flag again in case someone else downloaded this while we were waiting for the lock
+				if (File.Exists (flagFile))
+					return true;
 
 				if (!File.Exists (xbd.CacheFile) || !IsValidDownload (xbd.DestinationDir + ".sha256", xbd.CacheFile, xbd.Sha256)) {
 					try {


### PR DESCRIPTION
Occasionally on CI we see messages like this:

```
/Users/runner/.nuget/packages/xamarin.build.download/0.11.3/buildTransitive/Xamarin.Build.Download.targets(52,3): 
The file '/Users/runner/Library/Caches/XamarinBuildDownload/playservicesbasement-18.1.0/playservicesbasement-18.1.0.aar'
already exists. [/Users/runner/work/1/s/generated/com.google.assistant.appactions.widgets/com.google.assistant.appactions.widgets.csproj]
```

In the log we can see that we tried to use XDB to download this file twice at the same time:

```
// com.google.assistant.appactions.suggestions.csproj
Start: 2022-10-12 16:00:34.7892260
End: 2022-10-12 16:00:35.4315150
Downloading https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/18.1.0/play-services-basement-18.1.0.aar to /Users/runner/Library/Caches/XamarinBuildDownload/playservicesbasement-18.1.0.aar
```

```
// com.google.assistant.appactions.widgets.csproj
Start: 2022-10-12 16:00:35.1521780
End: 2022-10-12 16:00:35.7901080
Downloading https://dl.google.com/dl/android/maven2/com/google/android/gms/play-services-basement/18.1.0/play-services-basement-18.1.0.aar to /Users/runner/Library/Caches/XamarinBuildDownload/playservicesbasement-18.1.0.aar
```

The first one succeeds but the second one fails with the "file already exists" errors.

Attempt to guard against this by checking for the "already downloaded" flag a second time once we acquire the directory lock.  This way we should bail if another process completed the download while we were waiting for them to release the lock.