### PR TITLE
[ci] Enable CodeQL static analysis.

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -63,18 +63,23 @@ jobs:
           linux:
             poolName: ${{ parameters.linuxAgentPoolName }}
             imageName: ${{ parameters.linuxImage }}
+            runCodeQL: false
         ${{ if ne(parameters.macosImage, '') }}:
           macos:
             poolName: ${{ parameters.macosAgentPoolName }}
             imageName: ${{ parameters.macosImage }}
+            runCodeQL: false
         ${{ if ne(parameters.windowsImage, '') }}:
           windows:
             poolName: ${{ parameters.windowsAgentPoolName }}
             imageName: ${{ parameters.windowsImage }}
+            runCodeQL: true
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     continueOnError: ${{ eq(parameters.continueOnError, 'true') }}
     dependsOn: ${{ parameters.dependsOn }}
+    variables:
+      Codeql.Enabled: $(runCodeQL)
     pool:
       name: $(poolName)
       vmImage: $(imageName)


### PR DESCRIPTION
Enable CodeQL static analysis for [AndroidX](https://github.com/xamarin/AndroidX) and [GPS](https://github.com/xamarin/GooglePlayServicesComponents) repositories.

Note this `.yaml` is not used by _this_ repository.

Only run CodeQL on the Windows build lane.

It's hard to test this since it only runs on `main` builds, but I did run a test against AndroidX with https://github.com/xamarin/AndroidX/pull/651 to at least ensure that normal builds do not break.