### PR TITLE
Switch `AfterTargets` trigger for `_SRSCopySwiftDependencies` to `BeforeCodesign`

### DIFF
--- a/iOS/SwiftRuntimeSupport/source/SwiftRuntimeSupport.targets
+++ b/iOS/SwiftRuntimeSupport/source/SwiftRuntimeSupport.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-        <_SRSMasterAfterTargets>_CodesignNativeLibraries</_SRSMasterAfterTargets>
+        <_SRSMasterAfterTargets>BeforeCodesign</_SRSMasterAfterTargets>
         <_SRSMasterDependsOnTargets>_SRSCopySwiftDependencies</_SRSMasterDependsOnTargets>
         <_XcodeToolChainRelativeToSdkRoot>/../../../../../Toolchains/XcodeDefault.xctoolchain/</_XcodeToolChainRelativeToSdkRoot>
         <_TargetPlatform Condition=" '$(Platform)' == 'iPhoneSimulator' ">iphonesimulator</_TargetPlatform>


### PR DESCRIPTION
The existing trigger (`_CodesignNativeLibraries`) no longer exists in recent versions of the Xamarin.iOS targets.
Fixes https://github.com/xamarin/XamarinComponents/issues/1423