### PR TITLE
[ci] Add Post Checkout Steps

### DIFF
--- a/.ci/build.yml
+++ b/.ci/build.yml
@@ -10,6 +10,7 @@ parameters:
   initSteps: []                                             # any steps to run before .NET global tools are installed
   preBuildSteps: []                                         # any steps that need to run just before the main compilation starts
   postBuildSteps: []                                        # any steps that need to run just after the main compilation ends
+  postCheckoutSteps: []                                     # any steps that need to run just after the repository was checked out
   postDiffBuildSteps: []                                    # any steps that need to run after the API Diff ends
   masterBranchName: 'main'                                  # the "master" branch that should be used - can be something other than "master"
   installAppleCertificates: 'true'                          # whether or not to install the Apple certificates and provisioning profiles
@@ -86,6 +87,8 @@ jobs:
     steps:
       - checkout: self
         submodules: ${{ parameters.submodules }}
+      # custom post checkout steps
+      - ${{ parameters.postCheckoutSteps }}
       # before the build starts, make sure the tooling is as expected
       - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.mono }}
         displayName: 'Switch to the latest Xamarin SDK'


### PR DESCRIPTION
I ran into an issue with the hosted build agents where not all the required SDKs have been installed. In this case Xamarin.iOS. The macOS 13 agents don't have Xamarin.iOS installed anymore, but do have Xcode 15 and macOS 12 has Xamarin.iOS but not Xcode 15.

All the custom steps in this template come just too late for me to set that up properly and let the pipeline run successfully.

This change adds the ability to add custom steps right after the repository checkout so you can add additional installations/configuration to the build agent before everything else starts to run.